### PR TITLE
Fix GitHub Action Workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: node_modules
-          key: nodeModules-${{ hashFiles('**/yarn.lock') }}
+          key: nodeModules-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             nodeModules-
 

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -14,6 +14,14 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Use cached node_modules
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: nodeModules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            nodeModules-
+
       - name: Build
         run: |
           yarn

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -22,10 +22,11 @@ jobs:
           restore-keys: |
             nodeModules-
 
-      - name: Build
-        run: |
-          yarn
-          yarn doc
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build Docs
+        run: npm run doc
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "ts-node": "^9.1.1",
         "tsconfig-paths-webpack-plugin": "^3.3.0",
         "typedoc": "^0.20.5",
-        "typescript": "^4.1.5",
+        "typescript": ">=4.1.5 <4.3.0",
         "webpack": "^5.11.1",
         "webpack-bundle-analyzer": "^4.3.0",
         "webpack-cli": "^4.3.0"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "ts-node": "^9.1.1",
     "tsconfig-paths-webpack-plugin": "^3.3.0",
     "typedoc": "^0.20.5",
-    "typescript": "^4.1.5",
+    "typescript": ">=4.1.5 <4.3.0",
     "webpack": "^5.11.1",
     "webpack-bundle-analyzer": "^4.3.0",
     "webpack-cli": "^4.3.0"


### PR DESCRIPTION
There were two issues with the GitHub Action workflows:
1. npm dependencies were not being properly cached in the CI workflow
2. The TypeDoc workflow was failing, causing GitHub Pages to not be updated

This was because:
- `yarn` was removed in favor of `npm` in 7bcbd6096366b47502507e27e1b57721500bb515, but the workflows were never updated.
- In the CI workflow, `yarn.lock` was still being used as the node_modules cache key
- In the TypeDoc workflow, the `yarn` commands were still being used
- Since there was no `yarn.lock`, `yarn` would install the latest versions of all dependencies permitted in `package.json`, including `typescript 4.3`, which TypeDoc does not yet support. This ultimately caused that workflow to fail.

This PR:
1. Updates the CI workflow to use `package-lock.json` as the node_modules cache key
2. Limits `typescript` to `<4.3.0` in `package.json` (mostly just to guard against a future update that again breaks the TypeDoc workflow). `typescript` was not updated. 
3. Caches node_modules in the TypeDoc workflow (just like the CI workflow)
4. Installs dependencies and builds docs via `npm` instead of `yarn` in the TypeDoc workflow

This should resolve any broken links on the [GitHub Page](https://terra-money.github.io/terra.js/), as I believe they're just related to the page not updating recently due to the broken workflow. 