### PR TITLE
Increase default gas adjustment

### DIFF
--- a/integration-tests/estimateFee.ts
+++ b/integration-tests/estimateFee.ts
@@ -1,8 +1,9 @@
-import { LCDClient, LocalTerra, MsgSwap, Coin, StdTx, StdFee } from '../src';
+import { LCDClient, LocalTerra, MsgSwap, MsgSend, Coin, StdTx, StdFee } from '../src';
 import Axios from 'axios';
 
 const lt = new LocalTerra();
 const test1 = lt.wallets.test1;
+const test2 = lt.wallets.test2;
 
 async function main() {
   const { data: tequilaGasPrices } = await Axios.get(
@@ -22,7 +23,7 @@ async function main() {
     { gas: '500000' }
   );
 
-  console.log(rawFee.toJSON());
+  console.log('MsgSwap(500000 gas): ', rawFee.toJSON());
 
   // Test automatic fee estimation using create method with specified denom
   const item = await tequila.tx.create(test1.key.accAddress, {
@@ -30,7 +31,14 @@ async function main() {
     feeDenoms: ['uusd'],
   });
 
-  console.log(item.fee.toJSON());
+  console.log('MsgSwap(uusd fee)', item.fee.toJSON());
+
+  const send = await tequila.tx.create(test2.key.accAddress, {
+    msgs: [new MsgSend(test2.key.accAddress, test1.key.accAddress, '1234uusd')],
+    feeDenoms: ['uusd'],
+  });
+
+  console.log('MsgSend', send.fee.toJSON());
 }
 
 main().catch(console.error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@terra-money/terra.js",
-      "version": "1.8.7",
+      "version": "1.8.8",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "description": "The JavaScript SDK for Terra",
   "license": "MIT",
   "author": "Terraform Labs, PTE.",

--- a/src/client/lcd/LCDClient.ts
+++ b/src/client/lcd/LCDClient.ts
@@ -45,7 +45,7 @@ export interface LCDClientConfig {
 }
 
 const DEFAULT_LCD_OPTIONS: Partial<LCDClientConfig> = {
-  gasAdjustment: 1.4,
+  gasAdjustment: 1.75,
 };
 
 const DEFAULT_GAS_PRICES_BY_CHAIN_ID: { [key: string]: Coins.Input } = {


### PR DESCRIPTION
## Description
There is a weird bug in core that estimate fee returns too low gas depending on the address you put for MsgSend which leads terra.js to create failed tx caused by `out of gas` error. To fix this problem, this PR increases gas adjustment to 1.75 which was proven by several dApps