### PR TITLE
Handle mismatching coins in estimateFee gasPrices and feeDenoms

### DIFF
--- a/src/client/lcd/api/TxAPI.ts
+++ b/src/client/lcd/api/TxAPI.ts
@@ -237,9 +237,12 @@ export class TxAPI extends BaseAPI {
     if (gasPrices) {
       gasPricesCoins = new Coins(gasPrices);
       if (feeDenoms) {
-        gasPricesCoins = gasPricesCoins.filter(c =>
+        const gasPricesCoinsFiltered = gasPricesCoins.filter(c =>
           feeDenoms.includes(c.denom)
         );
+        if (gasPricesCoinsFiltered.toArray().length > 0) {
+          gasPricesCoins = gasPricesCoinsFiltered;
+        }
       }
     }
 


### PR DESCRIPTION
I was working on integrating ZenGo wallet for Terra Bombay testnet and noticed an issue when trying to estimate the fee of a transaction.

The problem occurs when trying to call the `estimateFee` function such that the intersection of the denom coins of the `gasPrice` parameter and the `feeDenoms` parameter are an empty set. The `filter` applied to the `gasPricesCoins` variable leaves it as an empty set of `Coins` which causes the resulting estimated fee to ignore the gas portion of the fee, resulting in 
an `insufficient fee` error when trying to send a tx based on the resulting (erroneous) fees.

--------------------------------------------------------------------------
**Commit message**
The existing issue with the estimateFee function is that the
'gasPricesCoins' variable can end up being an empty 'Coins' value.
One way the issue can be manifested is as in the following scenario:

1. The 'feeDenoms' const is initialized with ['uluna'].
2. gasPrices are not given with a 'uluna' denominator.
3. The 'gasPricesCoins' is filtered and left as an empty 'Coins'.
4. This array will be sent in the 'gas_prices' argument to the
   '/txs/estimate_fee' route in the lcd.
5. The lcd will process the request and will ignore the gas portion of
   the fee, incurring only stability fees and send the response to the
   client.
6. The client, trying to broadcast the resutling transaction based on
   the fee received in the previous step will receive an 'insufficient fees'
   error from the network.

The suggested solution checks that if the filter results in an empty
'Coins' value then the feeDenoms will be ignored and the fee
denominators that will be used are any of those constituted within the
'gasPrices' variable.

It is worth mentioning that this solution is a best-effort to avoid
breaking the API in which the estimateFee could possibly return
'Promise<StdFee|undefined>' where an 'undefined' value can be returned
if the aforementioned filter will result in an empty set of Coins.