### PR TITLE
Wasm message compatibility for Bombay/Columbus-5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@terra-money/terra.js",
-      "version": "1.8.8",
+      "version": "1.8.9",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "description": "The JavaScript SDK for Terra",
   "license": "MIT",
   "author": "Terraform Labs, PTE.",

--- a/src/client/lcd/APIRequester.ts
+++ b/src/client/lcd/APIRequester.ts
@@ -13,6 +13,7 @@ export class APIRequester {
       headers: {
         Accept: 'application/json',
       },
+      timeout: 30000,
     });
   }
 

--- a/src/client/lcd/LCDClient.ts
+++ b/src/client/lcd/LCDClient.ts
@@ -21,6 +21,7 @@ import { Wallet } from './Wallet';
 import { Numeric } from '../../core/numeric';
 import { Coins } from '../../core/Coins';
 import { Key } from '../../key';
+import { setContractEncoding } from '../../util/contract';
 
 export interface LCDClientConfig {
   /**
@@ -113,6 +114,13 @@ export class LCDClient {
         DEFAULT_GAS_PRICES_BY_CHAIN_ID['default'],
       ...config,
     };
+
+    // TODO: Deprcate this after columbus-5/bombay
+    // Make wasm module compatible with bombay network. Because it is a global flag,
+    // it doesn't support columbus-4/tequila and columbus-5/bombay at the same time
+    setContractEncoding(
+      !/^(?:columbus-5|bombay|localterra)/.test(config.chainID)
+    );
 
     this.apiRequester = new APIRequester(this.config.URL);
 

--- a/src/client/lcd/api/WasmAPI.ts
+++ b/src/client/lcd/api/WasmAPI.ts
@@ -1,5 +1,6 @@
 import { BaseAPI } from './BaseAPI';
 import { AccAddress } from '../../../core/bech32';
+import { b64ToDict } from '../../../util/contract';
 
 export interface CodeInfo {
   code_hash: string;
@@ -52,7 +53,7 @@ export class WasmAPI extends BaseAPI {
         code_id: Number.parseInt(d.code_id),
         address: d.address,
         owner: d.owner,
-        init_msg: JSON.parse(Buffer.from(d.init_msg, 'base64').toString()),
+        init_msg: b64ToDict(d.init_msg),
         migratable: d.migratable,
       }));
   }

--- a/src/util/contract.ts
+++ b/src/util/contract.ts
@@ -1,6 +1,17 @@
 import { BlockTxBroadcastResult, isTxError } from '../client/lcd/api/TxAPI';
 import { TxInfo } from '../core/TxInfo';
 
+let useEncoding = true;
+
+/**
+ * columbus-5/bombay doesn't encode msgs into base64 string.
+ * This function is for making main branch to be compatible with the change.
+ * Will be deprecated after bombay branch is merged into main branch
+ */
+export function setContractEncoding(flag: boolean) {
+  useEncoding = flag;
+}
+
 /**
  * Serializes a JavaScript object to a Base64-encoded string. If the data passed is
  * already a string, it will not be serialized and just return as-is.
@@ -9,6 +20,10 @@ import { TxInfo } from '../core/TxInfo';
  * @returns base64-encoded string
  */
 export function dictToB64(data: any): string {
+  if (!useEncoding) {
+    return data;
+  }
+
   // if data is just a plain string, it was not valid Base64-encoded JSON so it could not be parsed
   if (typeof data === 'string') {
     return data;
@@ -24,7 +39,11 @@ export function dictToB64(data: any): string {
  * @param data string
  * @returns converted object
  */
-export function b64ToDict(data: string): any {
+export function b64ToDict(data: any): any {
+  if (!useEncoding) {
+    return data;
+  }
+
   try {
     return JSON.parse(Buffer.from(data, 'base64').toString());
   } catch {


### PR DESCRIPTION
## Changes
* When constructing LCDClient, it will call a function for enable/disabling  base64 encoding for wasm messages. (e.g. init_msg, execute_msg and migrate_msg) depending on the chain id provided. For Bombay/Columbus-5, it will disable the encoding.
* Default 30 seconds timeout for Axios to avoid deadlock situtation.