### PR TITLE
[Feature] Remove null property from wasm execute msg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@terra-money/terra.js",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "The JavaScript SDK for Terra",
   "license": "MIT",
   "author": "Terraform Labs, PTE.",

--- a/src/core/wasm/msgs/MsgExecuteContract.ts
+++ b/src/core/wasm/msgs/MsgExecuteContract.ts
@@ -1,4 +1,4 @@
-import { JSONSerializable } from '../../../util/json';
+import { JSONSerializable, removeNull } from '../../../util/json';
 import { AccAddress } from '../../bech32';
 import { Coins } from '../../Coins';
 export class MsgExecuteContract extends JSONSerializable<MsgExecuteContract.Data> {
@@ -34,12 +34,13 @@ export class MsgExecuteContract extends JSONSerializable<MsgExecuteContract.Data
 
   public toData(): MsgExecuteContract.Data {
     const { sender, contract, execute_msg, coins } = this;
+
     return {
       type: 'wasm/MsgExecuteContract',
       value: {
         sender,
         contract,
-        execute_msg,
+        execute_msg: removeNull(execute_msg),
         coins: coins.toData(),
       },
     };

--- a/src/core/wasm/msgs/MsgInstantiateContract.ts
+++ b/src/core/wasm/msgs/MsgInstantiateContract.ts
@@ -1,4 +1,4 @@
-import { JSONSerializable } from '../../../util/json';
+import { JSONSerializable, removeNull } from '../../../util/json';
 import { AccAddress } from '../../bech32';
 import { Coins } from '../../Coins';
 
@@ -46,7 +46,7 @@ export class MsgInstantiateContract extends JSONSerializable<MsgInstantiateContr
         sender,
         admin,
         code_id: code_id.toFixed(),
-        init_msg,
+        init_msg: removeNull(init_msg),
         init_coins: init_coins.toData(),
       },
     };

--- a/src/core/wasm/msgs/MsgInstantiateContract.ts
+++ b/src/core/wasm/msgs/MsgInstantiateContract.ts
@@ -44,7 +44,7 @@ export class MsgInstantiateContract extends JSONSerializable<MsgInstantiateContr
       type: 'wasm/MsgInstantiateContract',
       value: {
         sender,
-        admin,
+        admin: admin === '' || admin === null ? undefined : admin,
         code_id: code_id.toFixed(),
         init_msg: removeNull(init_msg),
         init_coins: init_coins.toData(),

--- a/src/core/wasm/msgs/MsgMigrateContract.ts
+++ b/src/core/wasm/msgs/MsgMigrateContract.ts
@@ -1,4 +1,4 @@
-import { JSONSerializable } from '../../../util/json';
+import { JSONSerializable, removeNull } from '../../../util/json';
 import { AccAddress } from '../../bech32';
 export class MsgMigrateContract extends JSONSerializable<MsgMigrateContract.Data> {
   /**
@@ -36,7 +36,7 @@ export class MsgMigrateContract extends JSONSerializable<MsgMigrateContract.Data
         admin,
         contract,
         new_code_id: new_code_id.toFixed(),
-        migrate_msg,
+        migrate_msg: removeNull(migrate_msg),
       },
     };
   }

--- a/src/util/json.spec.ts
+++ b/src/util/json.spec.ts
@@ -1,0 +1,36 @@
+import { removeNull } from './json';
+
+describe('removeNull', () => {
+  it('remove null ', () => {
+    expect(
+      removeNull({
+        a: 'abc',
+        b: {
+          a: null,
+          b: 123,
+        },
+        c: null,
+        d: [123],
+        e: {
+          a: {
+            a: null,
+            b: 'abc',
+          },
+          b: 123,
+        },
+      })
+    ).toEqual({
+      a: 'abc',
+      b: {
+        b: 123,
+      },
+      d: [123],
+      e: {
+        a: {
+          b: 'abc',
+        },
+        b: 123,
+      },
+    });
+  });
+});

--- a/src/util/json.ts
+++ b/src/util/json.ts
@@ -24,3 +24,17 @@ export abstract class JSONSerializable<T> {
     return JSON.stringify(prepareSignBytes(this.toData()));
   }
 }
+
+export function removeNull(obj: any): any {
+  if (obj !== null && typeof obj === 'object') {
+    Object.keys(obj).forEach(function (key) {
+      if (obj[key] === null) {
+        delete obj[key];
+      } else if (typeof obj[key] === 'object') {
+        removeNull(obj[key]);
+      }
+    });
+  }
+
+  return obj;
+}


### PR DESCRIPTION
close #119 

After the core changed its wasm msg type to json.RawMessage, it automatically remove null properties at decoding. To prevent verification error, js also need to remove null properties at building sign data.

also replace empty string admin to undefined at wasm.instantiate

