### PR TITLE
feat: add iterable interface to Coins

### DIFF
--- a/src/core/Coins.spec.ts
+++ b/src/core/Coins.spec.ts
@@ -113,4 +113,26 @@ describe('Coins', () => {
       new Coins({ ukrw: '178.05' })
     );
   });
+
+  it('is iterable', () => {
+    const gasPrices = new Coins({
+      uluna: '0.15',
+      usdr: '0.1018',
+      uusd: '0.15',
+      ukrw: '178.05',
+      umnt: '431.6259',
+      ueur: '0.125',
+      ucny: '0.97',
+      ujpy: '16.0',
+      ugbp: '0.11',
+      uinr: '11.0',
+      ucad: '0.19',
+      uchf: '0.13',
+      uaud: '0.19',
+      usgd: '0.2',
+    });
+
+    // shouldn't fail or ts giving errors on type
+    expect(Array.isArray(Array.from(gasPrices))).toBe(true);
+  });
 });

--- a/src/core/Coins.ts
+++ b/src/core/Coins.ts
@@ -10,9 +10,22 @@ import { Numeric } from './numeric';
  */
 export class Coins
   extends JSONSerializable<Coins.Amino, Coins.Data, Coins.Proto>
-  implements Numeric<Coins>
+  implements Numeric<Coins>, Iterable<Coin.Data>
 {
   private _coins: Coins.ReprDict;
+
+  // implement iterator interface for interop
+  [Symbol.iterator]() {
+    let index = -1;
+    const data = this.toArray();
+
+    return {
+      next: () => ({
+        value: data[++index],
+        done: (index === data.length) as true,
+      }),
+    };
+  }
 
   /**
    * Converts the Coins information to a comma-separated list.


### PR DESCRIPTION
Adding `Iterable` interface to `Coins` construct. 

- This is useful when `Coins` need to be serialized into `Coin[]` by default javascript behaviours (i.e. tossing around in GraphQL resolver chains).
- Makes sense as the nominal type for `Coins` is `Coin[]` anyway, and object representation is optional.
- Does NOT affect any methods.