### PR TITLE
Pubkey can be null in tx info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@terra-money/terra.js",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "The JavaScript SDK for Terra",
   "license": "MIT",
   "author": "Terraform Labs, PTE.",

--- a/src/core/StdSignature.ts
+++ b/src/core/StdSignature.ts
@@ -17,20 +17,28 @@ export class StdSignature extends JSONSerializable<StdSignature.Data> {
 
   public static fromData(data: StdSignature.Data): StdSignature {
     const { signature, pub_key } = data;
-    return new StdSignature(signature, PublicKey.fromData(pub_key));
+    return new StdSignature(
+      signature,
+      PublicKey.fromData(
+        pub_key || {
+          type: 'tendermint/PubKeySecp256k1',
+          value: '',
+        }
+      )
+    );
   }
 
   public toData(): StdSignature.Data {
     const { signature, pub_key } = this;
     return {
       signature,
-      pub_key: pub_key.toData(),
+      pub_key: pub_key?.toData(),
     };
   }
 }
 export namespace StdSignature {
   export interface Data {
     signature: string;
-    pub_key: PublicKey.Data;
+    pub_key: PublicKey.Data | null;
   }
 }


### PR DESCRIPTION
close #139 

I also read cosmos-sdk code, and it seems we can broadcast tx with empty pubkey when the signer pubkey is already known.