### PR TITLE
Removed Object mutation from `removeNull` utility and increased code coverage

### DIFF
--- a/src/util/json.spec.ts
+++ b/src/util/json.spec.ts
@@ -1,25 +1,26 @@
 import { removeNull } from './json';
 
 describe('removeNull', () => {
-  it('remove null ', () => {
-    expect(
-      removeNull({
-        a: 'abc',
-        b: {
-          a: null,
-          b: 123,
-        },
-        c: null,
-        d: [123],
-        e: {
-          a: {
-            a: null,
-            b: 'abc',
-          },
-          b: 123,
-        },
-      })
-    ).toEqual({
+  const object = {
+    a: 'abc',
+    b: {
+      a: null,
+      b: 123,
+    },
+    c: null,
+    d: [123],
+    e: {
+      a: {
+        a: null,
+        b: 'abc',
+      },
+      b: 123,
+    },
+  };
+
+  it('removes null values from object', () => {
+    const newObject = removeNull(object);
+    expect(newObject).toEqual({
       a: 'abc',
       b: {
         b: 123,
@@ -32,5 +33,20 @@ describe('removeNull', () => {
         b: 123,
       },
     });
+  });
+
+  it('does not mutate object', () => {
+    removeNull(object);
+    expect(object).toEqual(object);
+  });
+
+  it('returns object or primative if not Object', () => {
+    const string = 'string';
+    const number = 1;
+    const boolean = false;
+
+    expect(removeNull(string)).toEqual(string);
+    expect(removeNull(number)).toEqual(number);
+    expect(removeNull(boolean)).toEqual(boolean);
   });
 });

--- a/src/util/json.ts
+++ b/src/util/json.ts
@@ -27,6 +27,15 @@ export abstract class JSONSerializable<T> {
 
 export function removeNull(obj: any): any {
   if (obj !== null && typeof obj === 'object') {
+    return Object.entries(obj)
+      .filter(([_, v]) => v != null)
+      .reduce(
+        (acc, [k, v]) => ({
+          ...acc,
+          [k]: v === Object(v) && !Array.isArray(v) ? removeNull(v) : v,
+        }),
+        {}
+      );
     Object.keys(obj).forEach(function (key) {
       if (obj[key] === null) {
         delete obj[key];

--- a/src/util/json.ts
+++ b/src/util/json.ts
@@ -36,13 +36,6 @@ export function removeNull(obj: any): any {
         }),
         {}
       );
-    Object.keys(obj).forEach(function (key) {
-      if (obj[key] === null) {
-        delete obj[key];
-      } else if (typeof obj[key] === 'object') {
-        removeNull(obj[key]);
-      }
-    });
   }
 
   return obj;


### PR DESCRIPTION
The `removeNull` function mutated the object passed in, this is not ideal in the JavaScript world as we pass objects everywhere.

This PR removes that mutation and adds some additional tests around that as well as testing passing in non-Object primitives to increase the code coverage.