### PR TITLE
Run prettier formatting in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Code style
         run: |
           npm run lint
-          npm run prettier
+          npm run format
         env:
           CI: true
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,10 @@ jobs:
         env:
           CI: true
 
-      - name: Lint
-        run: npm run lint
+      - name: Code style
+        run: |
+          npm run lint
+          npm run prettier
         env:
           CI: true
 

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "scripts": {
     "build": "tsc --module commonjs && webpack --mode production",
     "test": "jest",
-    "prettier": "prettier --check ./src/**/*.ts",
-    "prettier:fix": "prettier --write ./src/**/*.ts",
+    "format": "prettier --check ./src/**/*.ts",
+    "format:fix": "prettier --write ./src/**/*.ts",
     "lint": "eslint src --ext .js,.ts",
     "lint:fix": "eslint src --ext .js,.ts --fix",
     "doc": "typedoc",
@@ -40,7 +40,7 @@
   "lint-staged": {
     "./src/**/*.ts": [
       "npm run lint:fix",
-      "npm run prettier:fix"
+      "npm run format:fix"
     ]
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -30,15 +30,17 @@
   "scripts": {
     "build": "tsc --module commonjs && webpack --mode production",
     "test": "jest",
-    "prettier": "prettier --write ./src/**/*.ts",
-    "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
+    "prettier": "prettier --check ./src/**/*.ts",
+    "prettier:fix": "prettier --write ./src/**/*.ts",
+    "lint": "eslint src --ext .js,.ts",
+    "lint:fix": "eslint src --ext .js,.ts --fix",
     "doc": "typedoc",
     "prepublishOnly": "npm run build"
   },
   "lint-staged": {
     "./src/**/*.ts": [
-      "prettier --write",
-      "eslint"
+      "npm run lint:fix",
+      "npm run prettier:fix"
     ]
   },
   "husky": {

--- a/src/client/lcd/api/AuthAPI.ts
+++ b/src/client/lcd/api/AuthAPI.ts
@@ -1,9 +1,4 @@
-import {
-  AccAddress,
-  Account,
-  Coins,
-  LazyGradedVestingAccount,
-} from '../../../core';
+import { AccAddress, Account, LazyGradedVestingAccount } from '../../../core';
 import { BaseAPI } from './BaseAPI';
 import { APIParams } from '../APIRequester';
 

--- a/src/core/Coin.spec.ts
+++ b/src/core/Coin.spec.ts
@@ -1,5 +1,4 @@
 import { Coin } from './Coin';
-import { Denom } from './index';
 import { Dec, Int } from './numeric';
 
 describe('Coin', () => {

--- a/src/core/auth/Account.spec.ts
+++ b/src/core/auth/Account.spec.ts
@@ -1,5 +1,4 @@
 import { Account } from './Account';
-import { Coins } from '../Coins';
 import { PublicKey } from '../PublicKey';
 
 const data = require('./Account.data.json');

--- a/src/core/auth/Account.ts
+++ b/src/core/auth/Account.ts
@@ -1,4 +1,3 @@
-import { Coins } from '../Coins';
 import { PublicKey } from '../PublicKey';
 import { JSONSerializable } from '../../util/json';
 import { AccAddress } from '../bech32';

--- a/src/key/CLIKey.ts
+++ b/src/key/CLIKey.ts
@@ -1,5 +1,5 @@
 import { Key, pubKeyFromPublicKey } from './Key';
-import { bech32 } from 'bech32'
+import { bech32 } from 'bech32';
 import { AccPubKey, AccAddress, ValAddress, ValPubKey } from '../core/bech32';
 import { StdSignMsg } from '../core/StdSignMsg';
 import { StdSignature } from '../core/StdSignature';
@@ -50,11 +50,14 @@ export class CLIKey extends Key {
       ).toString()
     );
 
-    const publicKeyString = JSON.parse(details.pubkey).key
-    const publicKey = Buffer.from(publicKeyString, 'base64')
+    const publicKeyString = JSON.parse(details.pubkey).key;
+    const publicKey = Buffer.from(publicKeyString, 'base64');
 
     this._accAddress = details.address;
-    this._accPubKey = bech32.encode('terrapub', Array.from(pubKeyFromPublicKey(publicKey)));
+    this._accPubKey = bech32.encode(
+      'terrapub',
+      Array.from(pubKeyFromPublicKey(publicKey))
+    );
   }
 
   /**
@@ -118,6 +121,7 @@ export class CLIKey extends Key {
           `${this.params.multisig ? `--multisig ${this.params.multisig}` : ''}`
       )
     ).toString();
+
     tmpobj.removeCallback();
     return StdSignature.fromData(JSON.parse(result));
   }

--- a/src/util/json.ts
+++ b/src/util/json.ts
@@ -28,7 +28,7 @@ export abstract class JSONSerializable<T> {
 export function removeNull(obj: any): any {
   if (obj !== null && typeof obj === 'object') {
     return Object.entries(obj)
-      .filter(([_, v]) => v != null)
+      .filter(([, v]) => v != null)
       .reduce(
         (acc, [k, v]) => ({
           ...acc,


### PR DESCRIPTION
The file `src/key/CLIKey.ts` had a couple of prettier formatting issues in master so I added a task to run prettier in the CI to raise these on PRs. 

- Updated to run prettier in CI along with the linting
- Fixed any eslint warnings
- Updated prettier task name to `format` as a more common script name