### PR TITLE
Add cosmos-sdk/MsgTransfer message to Msg type

### DIFF
--- a/src/core/Msg.ts
+++ b/src/core/Msg.ts
@@ -1,4 +1,5 @@
 import { BankMsg, MsgMultiSend, MsgSend } from './bank/msgs';
+import { CosmosMsg, MsgTransfer } from './cosmos-sdk/msgs';
 import {
   DistributionMsg,
   MsgModifyWithdrawAddress,
@@ -42,6 +43,7 @@ import {
 
 export type Msg =
   | BankMsg
+  | CosmosMsg
   | DistributionMsg
   | GovMsg
   | MarketMsg
@@ -54,6 +56,7 @@ export type Msg =
 export namespace Msg {
   export type Data =
     | BankMsg.Data
+    | CosmosMsg.Data
     | DistributionMsg.Data
     | GovMsg.Data
     | MarketMsg.Data
@@ -70,6 +73,10 @@ export namespace Msg {
         return MsgSend.fromData(data);
       case 'bank/MsgMultiSend':
         return MsgMultiSend.fromData(data);
+
+      // cosmos-sdk
+      case 'cosmos-sdk/MsgTransfer':
+        return MsgTransfer.fromData(data);
 
       // distribution
       case 'distribution/MsgModifyWithdrawAddress':

--- a/src/core/cosmos-sdk/msgs/MsgTransfer.ts
+++ b/src/core/cosmos-sdk/msgs/MsgTransfer.ts
@@ -3,21 +3,24 @@ import { JSONSerializable } from '../../../util/json';
 import { AccAddress } from '../../bech32';
 
 /**
- * A basic message for sending [[Coins]] between Terra accounts.
+ * MsgTransfer defines a msg to transfer fungible tokens (i.e Coins) between
+ * ICS20 enabled chains
  */
 export class MsgTransfer extends JSONSerializable<MsgTransfer.Data> {
   /**
-   * value of the transaction
+   * Token to be transferred
    */
   public token: Coin;
 
   /**
-   * @param sender sender's address
-   * @param receiver recipient's address
-   * @param token value of the transaction
-   * @param source_port: string,
-   * @param source_channel: string,
-   * @param timeout_height: string,
+   * @param sender sender's beck32 address
+   * @param receiver recipient's beck32 address
+   * @param {Coin.Data} token value of the transaction
+   * @param source_port port on which the packet will be sent,
+   * @param source_channel channel by which the packet will be sent,
+   * @param {Object} timeout_height timeout height relative to the current block height
+   * @param {string} timeout_height.revision_number timeout timestamp (in nanoseconds) relative to the current block timestamp
+   * @param {string} timeout_height.revision_height
    */
   constructor(
     public sender: AccAddress,

--- a/src/core/cosmos-sdk/msgs/MsgTransfer.ts
+++ b/src/core/cosmos-sdk/msgs/MsgTransfer.ts
@@ -1,0 +1,93 @@
+import { Coin } from '../../Coin';
+import { JSONSerializable } from '../../../util/json';
+import { AccAddress } from '../../bech32';
+
+/**
+ * A basic message for sending [[Coins]] between Terra accounts.
+ */
+export class MsgTransfer extends JSONSerializable<MsgTransfer.Data> {
+  /**
+   * value of the transaction
+   */
+  public token: Coin;
+
+  /**
+   * @param sender sender's address
+   * @param receiver recipient's address
+   * @param token value of the transaction
+   * @param source_port: string,
+   * @param source_channel: string,
+   * @param timeout_height: string,
+   */
+  constructor(
+    public sender: AccAddress,
+    public receiver: AccAddress,
+    token: Coin.Data,
+    public source_port: string,
+    public source_channel: string,
+    public timeout_height: any
+  ) {
+    super();
+    this.token = Coin.fromData(token);
+  }
+
+  public static fromData(data: MsgTransfer.Data): MsgTransfer {
+    const {
+      value: {
+        sender,
+        receiver,
+        token,
+        source_port,
+        source_channel,
+        timeout_height,
+      },
+    } = data;
+    return new MsgTransfer(
+      sender,
+      receiver,
+      token,
+      source_port,
+      source_channel,
+      timeout_height
+    );
+  }
+
+  public toData(): MsgTransfer.Data {
+    const {
+      sender,
+      receiver,
+      token,
+      source_port,
+      source_channel,
+      timeout_height,
+    } = this;
+    return {
+      type: 'cosmos-sdk/MsgTransfer',
+      value: {
+        source_port,
+        source_channel,
+        sender,
+        receiver,
+        token: token.toData(),
+        timeout_height,
+      },
+    };
+  }
+}
+
+export namespace MsgTransfer {
+  export interface Data {
+    type: 'cosmos-sdk/MsgTransfer';
+    value: {
+      source_port: string;
+      source_channel: string;
+      sender: AccAddress;
+      receiver: AccAddress;
+      token: Coin.Data;
+      timeout_height: {
+        revision_number: string;
+        revision_height: string;
+      };
+    };
+  }
+}

--- a/src/core/cosmos-sdk/msgs/index.ts
+++ b/src/core/cosmos-sdk/msgs/index.ts
@@ -1,0 +1,8 @@
+import { MsgTransfer } from './MsgTransfer';
+
+export * from './MsgTransfer';
+
+export type CosmosMsg = MsgTransfer;
+export namespace CosmosMsg {
+  export type Data = MsgTransfer.Data;
+}


### PR DESCRIPTION
Fixes terra-money/terra.js/issues/164

First pass at integrating with new cosmos-sdk transaction message `cosmos-sdk/MsgTransfer`.

Could do with some advice from those more experienced devs around what to do with the `sender` / `receiver` addresses since they may not be a Terra address.

Also need to read up on the values within `source_port` and `source_channel` from the Cosmos SDK.

```javascript
import {
  LCDClient,
} from '../src';

const columbus = new LCDClient({
  URL: 'https://lcd.terra.dev',
  chainID: 'columbus-5'
});

columbus.tx.txInfo("F9EB9352EC1279FE8E982379DD3D641890430FFE6A6149B9A0D2ECC9ECF14D57")
.then(res => console.log(res.tx.msg))
.catch(err => console.log(err));

// [
//   MsgTransfer {
//     sender: 'terra189pwa7dg283kxcaq3ynz6zw7sdavcyfs2pk4lm',
//     receiver: 'osmo1mckpl309t7jspah60vj36dhdua9r60cjk5sxf2',
//     source_port: 'transfer',
//     source_channel: 'channel-1',
//     timeout_height: { revision_number: '1', revision_height: '1807228' },
//     token: Coin { denom: 'uluna', amount: 11312500 }
//   }
// ]
```

### Documentation

- https://github.com/cosmos/cosmos-sdk/blob/v0.42.7/x/ibc/applications/transfer/types/tx.pb.go#L49
- https://github.com/cosmos/ibc/tree/master/spec/app/ics-020-fungible-token-transfer

### Todo

- [ ] Write tests
- [ ] Update Typedoc comments