### PR TITLE
fix: Types of paramters from GovAPI

### DIFF
--- a/src/client/lcd/api/GovAPI.spec.ts
+++ b/src/client/lcd/api/GovAPI.spec.ts
@@ -10,10 +10,10 @@ describe('GovAPI', () => {
     await expect(gov.parameters()).resolves.toMatchObject({
       deposit_params: {
         min_deposit: expect.any(Coins),
-        max_deposit_period: expect.any(Number),
+        max_deposit_period: expect.any(String),
       },
       voting_params: {
-        voting_period: expect.any(Number),
+        voting_period: expect.any(String),
       },
       tally_params: {
         quorum: expect.any(Dec),

--- a/src/client/lcd/api/GovAPI.ts
+++ b/src/client/lcd/api/GovAPI.ts
@@ -45,7 +45,7 @@ export interface DepositParams {
   min_deposit: Coins;
 
   /** Amount of time (in seconds) a proposal can take to acquire the necessary deposits to enter voting stage, after being submitted. */
-  max_deposit_period: number;
+  max_deposit_period: string;
 }
 
 export namespace DepositParams {
@@ -57,7 +57,7 @@ export namespace DepositParams {
 
 export interface VotingParams {
   /** Amount of time (in seconds) a proposal can take to get votes once voting has begun. */
-  voting_period: number;
+  voting_period: string;
 }
 
 export namespace VotingParams {


### PR DESCRIPTION
Response from below endpoint says that the periods are `string` not `number`.

https://lcd.terra.dev/cosmos/gov/v1beta1/params/voting
https://lcd.terra.dev/cosmos/gov/v1beta1/params/deposit