### PR TITLE
feat: Add ClientUpdateProposal type.

### DIFF
--- a/src/core/gov/Proposal.ts
+++ b/src/core/gov/Proposal.ts
@@ -3,6 +3,7 @@ import { Int } from '../numeric';
 import { JSONSerializable } from '../../util/json';
 import { CommunityPoolSpendProposal } from '../distribution/proposals';
 import { ParameterChangeProposal } from '../params/proposals';
+import { ClientUpdateProposal } from '../ibc/proposals';
 import { TextProposal } from './proposals';
 import {
   SoftwareUpgradeProposal,
@@ -229,7 +230,8 @@ export namespace Proposal {
     | CommunityPoolSpendProposal
     | ParameterChangeProposal
     | SoftwareUpgradeProposal
-    | CancelSoftwareUpgradeProposal;
+    | CancelSoftwareUpgradeProposal
+    | ClientUpdateProposal;
 
   export namespace Content {
     export type Amino =
@@ -237,21 +239,24 @@ export namespace Proposal {
       | CommunityPoolSpendProposal.Amino
       | ParameterChangeProposal.Amino
       | SoftwareUpgradeProposal.Amino
-      | CancelSoftwareUpgradeProposal.Amino;
+      | CancelSoftwareUpgradeProposal.Amino
+      | ClientUpdateProposal.Amino;
 
     export type Data =
       | TextProposal.Data
       | CommunityPoolSpendProposal.Data
       | ParameterChangeProposal.Data
       | SoftwareUpgradeProposal.Data
-      | CancelSoftwareUpgradeProposal.Data;
+      | CancelSoftwareUpgradeProposal.Data
+      | ClientUpdateProposal.Data;
 
     export type Proto =
       | TextProposal.Proto
       | CommunityPoolSpendProposal.Proto
       | ParameterChangeProposal.Proto
       | SoftwareUpgradeProposal.Proto
-      | CancelSoftwareUpgradeProposal.Proto;
+      | CancelSoftwareUpgradeProposal.Proto
+      | ClientUpdateProposal.Proto;
 
     export function fromAmino(amino: Proposal.Content.Amino): Proposal.Content {
       switch (amino.type) {
@@ -265,6 +270,8 @@ export namespace Proposal {
           return SoftwareUpgradeProposal.fromAmino(amino);
         case 'upgrade/CancelSoftwareUpgradeProposal':
           return CancelSoftwareUpgradeProposal.fromAmino(amino);
+        case 'ibc/ClientUpdateProposal':
+          return ClientUpdateProposal.fromAmino(amino);
       }
     }
 
@@ -280,6 +287,8 @@ export namespace Proposal {
           return SoftwareUpgradeProposal.fromData(data);
         case '/cosmos.upgrade.v1beta1.CancelSoftwareUpgradeProposal':
           return CancelSoftwareUpgradeProposal.fromData(data);
+        case '/ibc.core.client.v1.ClientUpdateProposal':
+          return ClientUpdateProposal.fromData(data);
       }
     }
 
@@ -296,6 +305,8 @@ export namespace Proposal {
           return SoftwareUpgradeProposal.unpackAny(anyProto);
         case '/cosmos.upgrade.v1beta1.CancelSoftwareUpgradeProposal':
           return CancelSoftwareUpgradeProposal.unpackAny(anyProto);
+        case '/ibc.core.client.v1.ClientUpdateProposal':
+          return ClientUpdateProposal.unpackAny(anyProto);
       }
 
       throw `Proposal content ${typeUrl} not recognized`;

--- a/src/core/ibc/proposals/ClientUpdateProposal.spec.ts
+++ b/src/core/ibc/proposals/ClientUpdateProposal.spec.ts
@@ -1,0 +1,15 @@
+import { ClientUpdateProposal } from './ClientUpdateProposal';
+
+describe('ClientUpdateProposal', () => {
+  const update: ClientUpdateProposal.Data = {
+    '@type': '/ibc.core.client.v1.ClientUpdateProposal',
+    title: 'Update expired ibc client',
+    description: 'Proposal to update an IBC client which has expired.',
+    subject_client_id: '07-tendermint-19',
+    substitute_client_id: '07-tendermint-64',
+  };
+
+  it('parses IBC client upgrade proposal', () => {
+    expect(ClientUpdateProposal.fromData(update)).toBeTruthy();
+  });
+});

--- a/src/core/ibc/proposals/ClientUpdateProposal.ts
+++ b/src/core/ibc/proposals/ClientUpdateProposal.ts
@@ -1,0 +1,139 @@
+import { JSONSerializable } from '../../../util/json';
+import { Any } from '@terra-money/terra.proto/google/protobuf/any';
+import { ClientUpdateProposal as ClientUpdateProposal_pb } from '@terra-money/terra.proto/ibc/core/client/v1/client';
+
+/**
+ * Proposal that allows updating IBC clients. If it passes, the substitute
+ * client's latest consensus state is copied over to the subject client.
+ */
+export class ClientUpdateProposal extends JSONSerializable<
+  ClientUpdateProposal.Amino,
+  ClientUpdateProposal.Data,
+  ClientUpdateProposal.Proto
+> {
+  public subjectClientId: string;
+  public substituteClientId: string;
+  /**
+   * @param title proposal's title
+   * @param description proposal's description
+   * @param subjectClientId client to update
+   * @param substituteClientId client to copy
+   */
+  constructor(
+    public title: string,
+    public description: string,
+    subjectClientId: string,
+    substituteClientId: string
+  ) {
+    super();
+    this.subjectClientId = subjectClientId;
+    this.substituteClientId = substituteClientId;
+  }
+
+  public static fromAmino(
+    data: ClientUpdateProposal.Amino
+  ): ClientUpdateProposal {
+    const {
+      value: { title, description, subjectClientId, substituteClientId },
+    } = data;
+    return new ClientUpdateProposal(
+      title,
+      description,
+      subjectClientId,
+      substituteClientId
+    );
+  }
+
+  public toAmino(): ClientUpdateProposal.Amino {
+    const { title, description, subjectClientId, substituteClientId } = this;
+    return {
+      type: 'ibc/ClientUpdateProposal',
+      value: {
+        title,
+        description,
+        subjectClientId,
+        substituteClientId,
+      },
+    };
+  }
+
+  public static fromData(
+    data: ClientUpdateProposal.Data
+  ): ClientUpdateProposal {
+    const { title, description, subject_client_id, substitute_client_id } =
+      data;
+    return new ClientUpdateProposal(
+      title,
+      description,
+      subject_client_id,
+      substitute_client_id
+    );
+  }
+
+  public toData(): ClientUpdateProposal.Data {
+    const { title, description, subjectClientId, substituteClientId } = this;
+    return {
+      '@type': '/ibc.core.client.v1.ClientUpdateProposal',
+      title,
+      description,
+      subject_client_id: subjectClientId,
+      substitute_client_id: substituteClientId,
+    };
+  }
+
+  public static fromProto(
+    proto: ClientUpdateProposal.Proto
+  ): ClientUpdateProposal {
+    return new ClientUpdateProposal(
+      proto.title,
+      proto.description,
+      proto.subjectClientId,
+      proto.substituteClientId
+    );
+  }
+
+  public toProto(): ClientUpdateProposal.Proto {
+    const { title, description, subjectClientId, substituteClientId } = this;
+    return ClientUpdateProposal_pb.fromPartial({
+      subjectClientId,
+      substituteClientId,
+      description,
+      title,
+    });
+  }
+
+  public packAny(): Any {
+    return Any.fromPartial({
+      typeUrl: '/ibc.core.client.v1.ClientUpdateProposal',
+      value: ClientUpdateProposal_pb.encode(this.toProto()).finish(),
+    });
+  }
+
+  public static unpackAny(msgAny: Any): ClientUpdateProposal {
+    return ClientUpdateProposal.fromProto(
+      ClientUpdateProposal_pb.decode(msgAny.value)
+    );
+  }
+}
+
+export namespace ClientUpdateProposal {
+  export interface Amino {
+    type: 'ibc/ClientUpdateProposal';
+    value: {
+      title: string;
+      description: string;
+      subjectClientId: string;
+      substituteClientId: string;
+    };
+  }
+
+  export interface Data {
+    '@type': '/ibc.core.client.v1.ClientUpdateProposal';
+    title: string;
+    description: string;
+    subject_client_id: string;
+    substitute_client_id: string;
+  }
+
+  export type Proto = ClientUpdateProposal_pb;
+}

--- a/src/core/ibc/proposals/index.ts
+++ b/src/core/ibc/proposals/index.ts
@@ -1,0 +1,1 @@
+export * from './ClientUpdateProposal';


### PR DESCRIPTION
We've had our first ClientUpdateProposal proposal: https://lcd.terra.dev/cosmos/gov/v1beta1/proposals/775

Terra.js is currently lacking support for parsing this proposal type which leads to the following situation: 

### Before

<img width="1121" alt="Screen Shot 2022-03-25 at 3 50 15 PM" src="https://user-images.githubusercontent.com/142006/160199003-acbc6400-4e90-40bf-b64c-e3cd75f60208.png">

### After

<img width="1095" alt="Screen Shot 2022-03-25 at 3 50 58 PM" src="https://user-images.githubusercontent.com/142006/160199097-f9a6fcf9-ed04-4b10-80cb-a546d07a09ce.png">

Preview of proposal details: 

<img width="1092" alt="Screen Shot 2022-03-25 at 3 51 44 PM" src="https://user-images.githubusercontent.com/142006/160199171-c84e5893-d2b3-4ef5-9f01-b517e3c460cd.png">

