### PR TITLE
fix(reimport): added `CLIKey` export to the module

### DIFF
--- a/src/key/index.ts
+++ b/src/key/index.ts
@@ -1,3 +1,4 @@
 export * from './Key';
 export * from './MnemonicKey';
 export * from './RawKey';
+export * from './CLIKey';


### PR DESCRIPTION
Not sure if CLIKey is inaccessible on purpose i.e. unstable/still in-development but it seems to be the only semi-smooth way to share keys between terrad and terra.js as of now without exporting the `terrad` key from the keychain. 

A less frictionless but safe solution would be to document how to recreate the key from raw bytes in terra.js given that there is enough exportable information for a competent developer to bridge the gap:

```bash 
$terrad keys export terradev
-----BEGIN TENDERMINT PRIVATE KEY-----
salt: ED03DCECA6AA0C97C64777ADEC081118
type: secp256k1
kdf: bcrypt

bQeIuMrPqIOuQHfQw9otw5o2XnNcTmVK3yltvGUipjYpr0K8SfevG+/KRkB2F4eh
VpUUj0tHh434QYoJd69pJ9U8tesVkKCruyOsiHI=
=Jkvg
-----END TENDERMINT PRIVATE KEY-----
```

```bash
$terrad keys export terradev --unsafe --unarmored-hex
WARNING: The private key will be exported as an unarmored hexadecimal string. USE AT YOUR OWN RISK. Continue? [y/N]: y
a4e53f3f4535b3ac20f9306070d3c41e16bc29a94c9234e844587abf92e57a20
```

Thoughts?