### PR TITLE
fix(clikey): changed default`terrad` home path

### DIFF
--- a/src/core/params/proposals/ParameterChangeProposal.spec.ts
+++ b/src/core/params/proposals/ParameterChangeProposal.spec.ts
@@ -52,31 +52,6 @@ const aminoJson: ParameterChangeProposal.Amino = {
         key: 'SlashFractionDowntime',
         value: '"0.0001"',
       },
-      {
-        subspace: 'treasury',
-        key: 'TaxPolicy',
-        value:
-          '{"rate_min":"0.0","rate_max":"0.0","cap":{"denom":"usdr","amount":"0"},"change_rate_max":"0.0"}',
-      },
-      {
-        subspace: 'treasury',
-        key: 'RewardPolicy',
-        value:
-          '{"rate_min":"0.0","rate_max":"1.0","cap":{"denom":"unused","amount":"0"},"change_rate_max":"0.0"}',
-      },
-      {
-        subspace: 'treasury',
-        key: 'SeigniorageBurdenTarget',
-        value: '"0.67"',
-      },
-      {
-        subspace: 'treasury',
-        key: 'MiningIncrement',
-        value: '"1.07"',
-      },
-      { subspace: 'treasury', key: 'WindowShort', value: '"4"' },
-      { subspace: 'treasury', key: 'WindowLong', value: '"52"' },
-      { subspace: 'treasury', key: 'WindowProbation', value: '"12"' },
       { subspace: 'oracle', key: 'VotePeriod', value: '"5"' },
       {
         subspace: 'oracle',

--- a/src/core/params/proposals/ParameterChangeProposal.spec.ts
+++ b/src/core/params/proposals/ParameterChangeProposal.spec.ts
@@ -52,6 +52,31 @@ const aminoJson: ParameterChangeProposal.Amino = {
         key: 'SlashFractionDowntime',
         value: '"0.0001"',
       },
+      {
+        subspace: 'treasury',
+        key: 'TaxPolicy',
+        value:
+          '{"rate_min":"0.0","rate_max":"0.0","cap":{"denom":"usdr","amount":"0"},"change_rate_max":"0.0"}',
+      },
+      {
+        subspace: 'treasury',
+        key: 'RewardPolicy',
+        value:
+          '{"rate_min":"0.0","rate_max":"1.0","cap":{"denom":"unused","amount":"0"},"change_rate_max":"0.0"}',
+      },
+      {
+        subspace: 'treasury',
+        key: 'SeigniorageBurdenTarget',
+        value: '"0.67"',
+      },
+      {
+        subspace: 'treasury',
+        key: 'MiningIncrement',
+        value: '"1.07"',
+      },
+      { subspace: 'treasury', key: 'WindowShort', value: '"4"' },
+      { subspace: 'treasury', key: 'WindowLong', value: '"52"' },
+      { subspace: 'treasury', key: 'WindowProbation', value: '"12"' },
       { subspace: 'oracle', key: 'VotePeriod', value: '"5"' },
       {
         subspace: 'oracle',

--- a/src/key/CLIKey.ts
+++ b/src/key/CLIKey.ts
@@ -36,7 +36,7 @@ export class CLIKey extends Key {
   constructor(private params: CLIKeyParams) {
     super();
     params.cliPath = params.cliPath || 'terrad';
-    params.home    = params.home || resolve(homedir(), '.terrad', 'config');
+    params.home = params.home || resolve(homedir(), '.terrad', 'config');
   }
 
   private generateCommand(args: string) {

--- a/src/key/CLIKey.ts
+++ b/src/key/CLIKey.ts
@@ -6,6 +6,8 @@ import { writeFileSync } from 'fs';
 import { SignDoc } from '../core/SignDoc';
 import { SignatureV2 } from '../core/SignatureV2';
 import { PublicKey } from '../core/PublicKey';
+import {resolve} from 'path'
+import {homedir} from 'os'
 
 interface CLIKeyParams {
   keyName: string;
@@ -34,6 +36,8 @@ export class CLIKey extends Key {
   constructor(private params: CLIKeyParams) {
     super();
     params.cliPath = params.cliPath || 'terrad';
+    params.cliPath = params.home    ||  resolve(homedir(), '.terrad', 'config');
+
   }
 
   private generateCommand(args: string) {

--- a/src/key/CLIKey.ts
+++ b/src/key/CLIKey.ts
@@ -36,7 +36,7 @@ export class CLIKey extends Key {
   constructor(private params: CLIKeyParams) {
     super();
     params.cliPath = params.cliPath || 'terrad';
-    params.cliPath = params.home    ||  resolve(homedir(), '.terrad', 'config');
+    params.home    = params.home || resolve(homedir(), '.terrad', 'config');
 
   }
 

--- a/src/key/index.ts
+++ b/src/key/index.ts
@@ -1,3 +1,4 @@
 export * from './Key';
 export * from './MnemonicKey';
 export * from './RawKey';
+export * from './CLIKey';


### PR DESCRIPTION
# Usage example

```typescript
import {CLIKey} from '@terra-money/terra.js'

const clikey = new CLIKey({
    'keyName':'terradev',
})
console.log(clikey.accAddress);
console.log(clikey.valAddress);
```


Current implementation panics with (truncated, full error at the bottom if interested):
```
Error: Command failed: terrad keys show terradev --output json --home /home/rxz/go/bin/terrad
Error: couldn't get client config: Config File "client" Not Found in "[/home/rxz/go/bin/terrad/config]"
```
With changed path: 
```typescript
terra1hw4twm4kajhjpl6qapg0pn2cdtpnagp65planh
terravaloper1hw4twm4kajhjpl6qapg0pn2cdtpnagp65wnqry
```
...having changed default home to `$HOME/.terrad/config`, which seems to be the default for the last few versions of core did the trick.  $HOME is per node's`os`. 



```bash
Error: couldn't get client config: Config File "client" Not Found in "[/home/rxz/go/bin/terrad/config]"
Usage:
  terrad keys show [name_or_address [name_or_address...]] [flags]


Error: Command failed: terrad keys show terradev --output json --home /home/rxz/go/bin/terrad
Error: couldn't get client config: Config File "client" Not Found in "[/home/rxz/go/bin/terrad/config]"
Usage:
  terrad keys show [name_or_address [name_or_address...]] [flags]

Flags:
  -a, --address                  Output the address only (overrides --output)
      --bech string              The Bech32 prefix encoding for a key (acc|val|cons) (default "acc")
  -d, --device                   Output the address in a ledger device
  -h, --help                     help for show
      --multisig-threshold int   K out of N required signatures (default 1)
  -p, --pubkey                   Output the public key only (overrides --output)

Global Flags:
      --home string              The application home directory (default "/home/rxz/.terra")
      --keyring-backend string   Select keyring's backend (os|file|test) (default "os")
      --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
      --log_format string        The logging format (json|plain) (default "plain")
      --log_level string         The logging level (trace|debug|info|warn|error|fatal|panic) (default "info")
      --output string            Output format (text|json) (default "text")
      --trace                    print out full stack trace on errors


    at checkExecSyncError (child_process.js:760:11)
    at execSync (child_process.js:833:15)
    at CLIKey.loadAccountDetails (/home/rxz/dev/TFL/create-send-tx/src/key/CLIKey.ts:47:15)
    at CLIKey.get (/home/rxz/dev/TFL/create-send-tx/src/key/CLIKey.ts:61:12)
    at Object.<anonymous> (/home/rxz/dev/TFL/create-send-tx/tx.ts:28:20)
    at Module._compile (internal/modules/cjs/loader.js:1072:14)
    at Module.m._compile (/home/rxz/.nvm/versions/node/v14.17.6/lib/node_modules/ts-node/src/index.ts:1371:23)
    at Module._extensions..js (internal/modules/cjs/loader.js:1101:10)
    at Object.require.extensions.<computed> [as .ts] (/home/rxz/.nvm/versions/node/v14.17.6/lib/node_modules/ts-node/src/index.ts:1374:12)
    at Module.load (internal/modules/cjs/loader.js:937:32) {
  status: 1,
  signal: null,
  output: [
    null,
    Buffer(0) [Uint8Array] [],
    Buffer(1292) [Uint8Array] [
       69, 114, 114, 111, 114,  58,  32,  99, 111, 117, 108, 100,
      110,  39, 116,  32, 103, 101, 116,  32,  99, 108, 105, 101,
      110, 116,  32,  99, 111, 110, 102, 105, 103,  58,  32,  67,
      111, 110, 102, 105, 103,  32,  70, 105, 108, 101,  32,  34,
       99, 108, 105, 101, 110, 116,  34,  32,  78, 111, 116,  32,
       70, 111, 117, 110, 100,  32, 105, 110,  32,  34,  91,  47,
      104, 111, 109, 101,  47, 114, 120, 122,  47, 103, 111,  47,
       98, 105, 110,  47, 116, 101, 114, 114,  97, 100,  47,  99,
      111, 110, 102, 105,
      ... 1192 more items
    ]
  ],
  pid: 241340,
  stdout: Buffer(0) [Uint8Array] [],
  stderr: Buffer(1292) [Uint8Array] [
     69, 114, 114, 111, 114,  58,  32,  99, 111, 117, 108, 100,
    110,  39, 116,  32, 103, 101, 116,  32,  99, 108, 105, 101,
    110, 116,  32,  99, 111, 110, 102, 105, 103,  58,  32,  67,
    111, 110, 102, 105, 103,  32,  70, 105, 108, 101,  32,  34,
     99, 108, 105, 101, 110, 116,  34,  32,  78, 111, 116,  32,
     70, 111, 117, 110, 100,  32, 105, 110,  32,  34,  91,  47,
    104, 111, 109, 101,  47, 114, 120, 122,  47, 103, 111,  47,
     98, 105, 110,  47, 116, 101, 114, 114,  97, 100,  47,  99,
    111, 110, 102, 105,
    ... 1192 more items
  ]
}
```
