### PR TITLE
fix(client:api-requester): allow special endpoint

### DIFF
--- a/src/client/lcd/APIRequester.spec.ts
+++ b/src/client/lcd/APIRequester.spec.ts
@@ -44,4 +44,16 @@ describe('APIRequester', () => {
       { params: {} }
     );
   });
+
+  it('accept an URL with credentials', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: null });
+
+    const request = new APIRequester('https://:123@lcd.terra.dev');
+    await request.get('/foo');
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'https://:123@lcd.terra.dev/foo',
+      { params: {} }
+    );
+  });
 });

--- a/src/client/lcd/APIRequester.spec.ts
+++ b/src/client/lcd/APIRequester.spec.ts
@@ -1,0 +1,47 @@
+import axios from 'axios';
+import { APIRequester } from './APIRequester';
+
+jest.mock('axios');
+const mockedAxios = jest.mocked(axios, true);
+
+describe('APIRequester', () => {
+  beforeAll(() => {
+    // @ts-expect-error
+    axios.create.mockReturnThis();
+  });
+
+  it('accept a standard URL', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: null });
+
+    const request = new APIRequester('https://lcd.terra.dev');
+    await request.get('/foo');
+
+    expect(mockedAxios.get).toHaveBeenCalledWith('https://lcd.terra.dev/foo', {
+      params: {},
+    });
+  });
+
+  it('accept a deep URL', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: null });
+
+    const request = new APIRequester('https://lcd.terra.dev/bar');
+    await request.get('/foo');
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'https://lcd.terra.dev/bar/foo',
+      { params: {} }
+    );
+  });
+
+  it('accept an URL with search params', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: null });
+
+    const request = new APIRequester('https://lcd.terra.dev?key=123');
+    await request.get('/foo');
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'https://lcd.terra.dev/foo?key=123',
+      { params: {} }
+    );
+  });
+});

--- a/src/client/lcd/APIRequester.ts
+++ b/src/client/lcd/APIRequester.ts
@@ -22,9 +22,12 @@ export interface PaginationOptions {
 
 export class APIRequester {
   private axios: AxiosInstance;
+  private readonly baseURL: string;
+
   constructor(baseURL: string) {
+    this.baseURL = baseURL;
+
     this.axios = Axios.create({
-      baseURL,
       headers: {
         Accept: 'application/json',
       },
@@ -32,25 +35,39 @@ export class APIRequester {
     });
   }
 
+  private computeEndpoint(endpoint: string) {
+    const url = new URL(this.baseURL);
+
+    url.pathname === '/'
+      ? (url.pathname = endpoint)
+      : (url.pathname += endpoint);
+
+    return url.toString();
+  }
+
   public async getRaw<T>(
     endpoint: string,
     params: URLSearchParams | APIParams = {}
   ): Promise<T> {
-    return this.axios.get(endpoint, { params }).then(d => d.data);
+    const url = this.computeEndpoint(endpoint);
+    return this.axios.get(url, { params }).then(d => d.data);
   }
 
   public async get<T>(
     endpoint: string,
     params: URLSearchParams | APIParams = {}
   ): Promise<T> {
-    return this.axios.get(endpoint, { params }).then(d => d.data);
+    const url = this.computeEndpoint(endpoint);
+    return this.axios.get(url, { params }).then(d => d.data);
   }
 
   public async postRaw<T>(endpoint: string, data?: any): Promise<T> {
-    return this.axios.post(endpoint, data).then(d => d.data);
+    const url = this.computeEndpoint(endpoint);
+    return this.axios.post(url, data).then(d => d.data);
   }
 
   public async post<T>(endpoint: string, data?: any): Promise<T> {
-    return this.axios.post(endpoint, data).then(d => d.data);
+    const url = this.computeEndpoint(endpoint);
+    return this.axios.post(url, data).then(d => d.data);
   }
 }


### PR DESCRIPTION
Hey there! 👋🏻 

This PR allows us to provide a special endpoint as LCD.

Currently, providing an endpoint with search parameters makes the whole thing break.
For example, if we were using `https://lcd.terra.dev?key=123` the endpoint would have been `https://lcd.terra.dev?key=123/foo/bar`.

Using the `URL()` API helps us to keep any search parameters in the URL.