### PR TITLE
fix parsing code_info.instantiate_permission by adding converter

### DIFF
--- a/src/client/lcd/api/WasmAPI.ts
+++ b/src/client/lcd/api/WasmAPI.ts
@@ -23,7 +23,7 @@ export namespace CodeInfo {
     code_id: string;
     code_hash: string;
     creator: AccAddress;
-    instantiate_config?: AccessConfig.Data;
+    instantiate_permission?: AccessConfig.Data;
   }
 }
 
@@ -129,8 +129,8 @@ export class WasmAPI extends BaseAPI {
         code_id: +d.code_id,
         code_hash: d.code_hash,
         creator: d.creator,
-        instantiate_config: d.instantiate_config
-          ? AccessConfig.fromData(d.instantiate_config)
+        instantiate_permission: d.instantiate_permission
+          ? AccessConfig.fromData(d.instantiate_permission)
           : undefined,
       }));
   }
@@ -322,8 +322,8 @@ export class WasmAPI extends BaseAPI {
             code_id: +codeInfo.code_id,
             code_hash: codeInfo.code_hash,
             creator: codeInfo.creator,
-            instantiate_config: codeInfo.instantiate_config
-              ? AccessConfig.fromData(codeInfo.instantiate_config)
+            instantiate_permission: codeInfo.instantiate_permission
+              ? AccessConfig.fromData(codeInfo.instantiate_permission)
               : undefined,
           };
         }),

--- a/src/core/wasm/AbsoluteTxPosition.ts
+++ b/src/core/wasm/AbsoluteTxPosition.ts
@@ -1,76 +1,77 @@
-import {
-    AbsoluteTxPosition as AbsoluteTxPosition_pb,
-} from '@terra-money/terra.proto/cosmwasm/wasm/v1/types';
+import { AbsoluteTxPosition as AbsoluteTxPosition_pb } from '@terra-money/terra.proto/cosmwasm/wasm/v1/types';
 import { JSONSerializable } from '../../util/json';
 import * as Long from 'long';
 /**
- * 
+ *
  */
 export class AbsoluteTxPosition extends JSONSerializable<
-    AbsoluteTxPosition.Amino,
-    AbsoluteTxPosition.Data,
-    AbsoluteTxPosition.Proto
+  AbsoluteTxPosition.Amino,
+  AbsoluteTxPosition.Data,
+  AbsoluteTxPosition.Proto
 > {
-    /**
-     * @param block_height 
-     * @param tx_index 
-     */
-    constructor(public block_height: number, public tx_index: number) {
-        super();
-    }
+  /**
+   * @param block_height
+   * @param tx_index
+   */
+  constructor(public block_height: number, public tx_index: number) {
+    super();
+  }
 
-    public static fromAmino(data: AbsoluteTxPosition.Amino): AbsoluteTxPosition {
-        return new AbsoluteTxPosition(Number.parseInt(data.block_height), Number.parseInt(data.tx_index));
-    }
+  public static fromAmino(data: AbsoluteTxPosition.Amino): AbsoluteTxPosition {
+    return new AbsoluteTxPosition(
+      Number.parseInt(data.block_height),
+      Number.parseInt(data.tx_index)
+    );
+  }
 
-    public toAmino(): AbsoluteTxPosition.Amino {
-        const res: AbsoluteTxPosition.Amino = {
-            block_height: this.block_height.toFixed(),
-            tx_index: this.tx_index.toFixed(),
-        }
-        return res;
-    }
+  public toAmino(): AbsoluteTxPosition.Amino {
+    const res: AbsoluteTxPosition.Amino = {
+      block_height: this.block_height.toFixed(),
+      tx_index: this.tx_index.toFixed(),
+    };
+    return res;
+  }
 
-    public static fromData(data: AbsoluteTxPosition.Data): AbsoluteTxPosition {
-        // FIXME: new core returns human-friendly string like 'Everybody'.
-        // but accessTypeFromJSON requires "ACCESS_TYPE_EVERYBODY"
-        // TODO: find out why the strings arent't matching
-        return new AbsoluteTxPosition(Number.parseInt(data.block_height), Number.parseInt(data.tx_index));
-    }
+  public static fromData(data: AbsoluteTxPosition.Data): AbsoluteTxPosition {
+    return new AbsoluteTxPosition(
+      Number.parseInt(data.block_height),
+      Number.parseInt(data.tx_index)
+    );
+  }
 
-    public toData(): AbsoluteTxPosition.Data {
-        const res: AbsoluteTxPosition.Data = {
-            block_height: this.block_height.toFixed(),
-            tx_index: this.tx_index.toFixed()
-        }
-        return res;
-    }
+  public toData(): AbsoluteTxPosition.Data {
+    const res: AbsoluteTxPosition.Data = {
+      block_height: this.block_height.toFixed(),
+      tx_index: this.tx_index.toFixed(),
+    };
+    return res;
+  }
 
-    public static fromProto(proto: AbsoluteTxPosition.Proto): AbsoluteTxPosition {
-        return new AbsoluteTxPosition(
-            proto.blockHeight.toNumber(),
-            proto.txIndex.toNumber()
-        );
-    }
+  public static fromProto(proto: AbsoluteTxPosition.Proto): AbsoluteTxPosition {
+    return new AbsoluteTxPosition(
+      proto.blockHeight.toNumber(),
+      proto.txIndex.toNumber()
+    );
+  }
 
-    public toProto(): AbsoluteTxPosition.Proto {
-        return AbsoluteTxPosition_pb.fromPartial({
-            blockHeight: Long.fromNumber(this.block_height),
-            txIndex: Long.fromNumber(this.tx_index)
-        });
-    }
+  public toProto(): AbsoluteTxPosition.Proto {
+    return AbsoluteTxPosition_pb.fromPartial({
+      blockHeight: Long.fromNumber(this.block_height),
+      txIndex: Long.fromNumber(this.tx_index),
+    });
+  }
 }
 
 export namespace AbsoluteTxPosition {
-    export interface Amino {
-        block_height: string;
-        tx_index: string;
-    }
+  export interface Amino {
+    block_height: string;
+    tx_index: string;
+  }
 
-    export interface Data {
-        block_height: string;
-        tx_index: string;
-    }
+  export interface Data {
+    block_height: string;
+    tx_index: string;
+  }
 
-    export type Proto = AbsoluteTxPosition_pb;
+  export type Proto = AbsoluteTxPosition_pb;
 }

--- a/src/core/wasm/AccessConfig.ts
+++ b/src/core/wasm/AccessConfig.ts
@@ -1,79 +1,85 @@
 import {
-    AccessType, accessTypeFromJSON, accessTypeToJSON,
-    AccessConfig as AccessConfig_pb,
+  AccessType,
+  accessTypeToJSON,
+  AccessConfig as AccessConfig_pb,
 } from '@terra-money/terra.proto/cosmwasm/wasm/v1/types';
 import { AccAddress } from 'core/bech32';
 import { JSONSerializable } from '../../util/json';
+import { convertAccessTypeFromJSON } from './util';
+
 export { AccessType };
 
 /**
- * 
+ *
  */
 export class AccessConfig extends JSONSerializable<
-    AccessConfig.Amino,
-    AccessConfig.Data,
-    AccessConfig.Proto
+  AccessConfig.Amino,
+  AccessConfig.Data,
+  AccessConfig.Proto
 > {
-    /**
-     * @param permission access type
-     * @param address 
-     */
-    constructor(public permission: AccessType, public address: AccAddress) {
-        super();
-    }
+  /**
+   * @param permission access type
+   * @param address
+   */
+  constructor(public permission: AccessType, public address: AccAddress) {
+    super();
+  }
 
-    public static fromAmino(data: AccessConfig.Amino): AccessConfig {
-        return new AccessConfig(accessTypeFromJSON(data.permission), data.address);
-    }
+  public static fromAmino(data: AccessConfig.Amino): AccessConfig {
+    return new AccessConfig(
+      convertAccessTypeFromJSON(data.permission),
+      data.address
+    );
+  }
 
-    public toAmino(): AccessConfig.Amino {
-        const res: AccessConfig.Amino = {
-            permission: accessTypeToJSON(this.permission),
-            address: this.address
-        }
-        return res;
-    }
+  public toAmino(): AccessConfig.Amino {
+    const res: AccessConfig.Amino = {
+      permission: accessTypeToJSON(this.permission),
+      address: this.address,
+    };
+    return res;
+  }
 
-    public static fromData(data: AccessConfig.Data): AccessConfig {
-        // FIXME: new core returns human-friendly string like 'Everybody'.
-        // but accessTypeFromJSON requires "ACCESS_TYPE_EVERYBODY"
-        // TODO: find out why the strings arent't matching
-        return new AccessConfig(accessTypeFromJSON(data.permission), data.address);
-    }
+  public static fromData(data: AccessConfig.Data): AccessConfig {
+    // FIXME: new core returns human-friendly string like 'Everybody'.
+    // but convertAccessTypeFromJSON requires "ACCESS_TYPE_EVERYBODY"
+    // TODO: find out why the strings arent't matching
+    return new AccessConfig(
+      convertAccessTypeFromJSON(data.permission),
+      data.address
+    );
+  }
 
-    public toData(): AccessConfig.Data {
-        const res: AccessConfig.Data = {
-            permission: accessTypeToJSON(this.permission),
-            address: this.address
-        }
-        return res;
-    }
+  public toData(): AccessConfig.Data {
+    const res: AccessConfig.Data = {
+      permission: accessTypeToJSON(this.permission),
+      address: this.address,
+    };
+    return res;
+  }
 
-    public static fromProto(proto: AccessConfig.Proto): AccessConfig {
-        return new AccessConfig(
-            proto.permission,
-            proto.address
-        );
-    }
+  public static fromProto(proto: AccessConfig.Proto): AccessConfig {
+    return new AccessConfig(proto.permission, proto.address);
+  }
 
-    public toProto(): AccessConfig.Proto {
-        return AccessConfig_pb.fromPartial({
-            permission: this.permission,
-            address: this.address
-        });
-    }
+  public toProto(): AccessConfig.Proto {
+    return AccessConfig_pb.fromPartial({
+      permission: this.permission,
+      address: this.address,
+    });
+  }
 }
 
 export namespace AccessConfig {
-    export interface Amino {
-        permission: string;
-        address: string;
-    }
+  export interface Amino {
+    permission: string;
+    address: string;
+  }
 
-    export interface Data {
-        permission: string;
-        address: string;
-    }
+  export interface Data {
+    permission: string;
+    address: string;
+  }
 
-    export type Proto = AccessConfig_pb;
+  export type Proto = AccessConfig_pb;
 }

--- a/src/core/wasm/AccessConfig.ts
+++ b/src/core/wasm/AccessConfig.ts
@@ -3,7 +3,7 @@ import {
   accessTypeToJSON,
   AccessConfig as AccessConfig_pb,
 } from '@terra-money/terra.proto/cosmwasm/wasm/v1/types';
-import { AccAddress } from 'core/bech32';
+import { AccAddress } from '../bech32';
 import { JSONSerializable } from '../../util/json';
 import { convertAccessTypeFromJSON } from './util';
 

--- a/src/core/wasm/AccessTypeParam.ts
+++ b/src/core/wasm/AccessTypeParam.ts
@@ -1,69 +1,69 @@
 import {
-    AccessType, accessTypeFromJSON, accessTypeToJSON,
-    AccessTypeParam as AccessTypeParam_pb,
+  AccessType,
+  accessTypeToJSON,
+  AccessTypeParam as AccessTypeParam_pb,
 } from '@terra-money/terra.proto/cosmwasm/wasm/v1/types';
 import { JSONSerializable } from '../../util/json';
+import { convertAccessTypeFromJSON } from './util';
 
 export { AccessType };
 
 /**
- * 
+ *
  */
 export class AccessTypeParam extends JSONSerializable<
-    AccessTypeParam.Amino,
-    AccessTypeParam.Data,
-    AccessTypeParam.Proto
+  AccessTypeParam.Amino,
+  AccessTypeParam.Data,
+  AccessTypeParam.Proto
 > {
-    /**
-     * @param value access type
-     */
-    constructor(public value: AccessType) {
-        super();
-    }
+  /**
+   * @param value access type
+   */
+  constructor(public value: AccessType) {
+    super();
+  }
 
-    public static fromAmino(data: AccessTypeParam.Amino): AccessTypeParam {
-        return new AccessTypeParam(accessTypeFromJSON(data.value));
-    }
+  public static fromAmino(data: AccessTypeParam.Amino): AccessTypeParam {
+    return new AccessTypeParam(convertAccessTypeFromJSON(data.value));
+  }
 
-    public toAmino(): AccessTypeParam.Amino {
-        const res: AccessTypeParam.Amino = {
-            value: accessTypeToJSON(this.value)
-        }
-        return res;
-    }
+  public toAmino(): AccessTypeParam.Amino {
+    const res: AccessTypeParam.Amino = {
+      value: accessTypeToJSON(this.value),
+    };
+    return res;
+  }
 
-    public static fromData(data: AccessTypeParam.Data): AccessTypeParam {
-        return new AccessTypeParam(accessTypeFromJSON(data.value));
-    }
+  public static fromData(data: AccessTypeParam.Data): AccessTypeParam {
+    return new AccessTypeParam(convertAccessTypeFromJSON(data.value));
+  }
 
-    public toData(): AccessTypeParam.Data {
-        const res: AccessTypeParam.Data = {
-            value: accessTypeToJSON(this.value)
-        }
-        return res;
-    }
+  public toData(): AccessTypeParam.Data {
+    const res: AccessTypeParam.Data = {
+      value: accessTypeToJSON(this.value),
+    };
+    return res;
+  }
 
-    public static fromProto(proto: AccessTypeParam.Proto): AccessTypeParam {
-        return new AccessTypeParam(
-            proto.value
-        );
-    }
+  public static fromProto(proto: AccessTypeParam.Proto): AccessTypeParam {
+    return new AccessTypeParam(proto.value);
+  }
 
-    public toProto(): AccessTypeParam.Proto {
-        return AccessTypeParam_pb.fromPartial({
-            value: this.value
-        });
-    }
+  public toProto(): AccessTypeParam.Proto {
+    return AccessTypeParam_pb.fromPartial({
+      value: this.value,
+    });
+  }
 }
 
 export namespace AccessTypeParam {
-    export interface Amino {
-        value: string;
-    }
+  export interface Amino {
+    value: string;
+  }
 
-    export interface Data {
-        value: string;
-    }
+  export interface Data {
+    value: string;
+  }
 
-    export type Proto = AccessTypeParam_pb;
+  export type Proto = AccessTypeParam_pb;
 }

--- a/src/core/wasm/HistoryEntry.ts
+++ b/src/core/wasm/HistoryEntry.ts
@@ -1,105 +1,104 @@
 import {
-    ContractCodeHistoryEntry as HistoryEntry_pb,
-    ContractCodeHistoryOperationType, contractCodeHistoryOperationTypeFromJSON, contractCodeHistoryOperationTypeToJSON
+  ContractCodeHistoryEntry as HistoryEntry_pb,
+  ContractCodeHistoryOperationType,
+  contractCodeHistoryOperationTypeFromJSON,
+  contractCodeHistoryOperationTypeToJSON,
 } from '@terra-money/terra.proto/cosmwasm/wasm/v1/types';
 import { JSONSerializable, removeNull } from '../../util/json';
 import * as Long from 'long';
 import { AbsoluteTxPosition } from './AbsoluteTxPosition';
 /**
- * 
+ *
  */
 export class HistoryEntry extends JSONSerializable<
-    HistoryEntry.Amino,
-    HistoryEntry.Data,
-    HistoryEntry.Proto
+  HistoryEntry.Amino,
+  HistoryEntry.Data,
+  HistoryEntry.Proto
 > {
-    /**
-     * @param operation access type
-     * @param code_id 
-     */
-    constructor(
-        public operation: ContractCodeHistoryOperationType,
-        public code_id: number,
-        public updated: AbsoluteTxPosition | undefined,
-        public msg: object | string
-    ) {
-        super();
-    }
+  /**
+   * @param operation access type
+   * @param code_id
+   */
+  constructor(
+    public operation: ContractCodeHistoryOperationType,
+    public code_id: number,
+    public updated: AbsoluteTxPosition | undefined,
+    public msg: object | string
+  ) {
+    super();
+  }
 
-    public static fromAmino(data: HistoryEntry.Amino): HistoryEntry {
-        return new HistoryEntry(
-            contractCodeHistoryOperationTypeFromJSON(data.operation),
-            Number.parseInt(data.code_id),
-            data.updated ? AbsoluteTxPosition.fromAmino(data.updated) : undefined,
-            data.msg
-        );
-    }
+  public static fromAmino(data: HistoryEntry.Amino): HistoryEntry {
+    return new HistoryEntry(
+      contractCodeHistoryOperationTypeFromJSON(data.operation),
+      Number.parseInt(data.code_id),
+      data.updated ? AbsoluteTxPosition.fromAmino(data.updated) : undefined,
+      data.msg
+    );
+  }
 
-    public toAmino(): HistoryEntry.Amino {
-        const res: HistoryEntry.Amino = {
-            operation: contractCodeHistoryOperationTypeToJSON(this.operation),
-            code_id: this.code_id.toFixed(),
-            updated: this.updated?.toAmino(),
-            msg: this.msg
-        }
-        return res;
-    }
+  public toAmino(): HistoryEntry.Amino {
+    const res: HistoryEntry.Amino = {
+      operation: contractCodeHistoryOperationTypeToJSON(this.operation),
+      code_id: this.code_id.toFixed(),
+      updated: this.updated?.toAmino(),
+      msg: this.msg,
+    };
+    return res;
+  }
 
-    public static fromData(data: HistoryEntry.Data): HistoryEntry {
-        // FIXME: new core returns human-friendly string like 'Everybody'.
-        // but accessTypeFromJSON requires "ACCESS_TYPE_EVERYBODY"
-        // TODO: find out why the strings arent't matching
-        return new HistoryEntry(
-            contractCodeHistoryOperationTypeFromJSON(data.operation),
-            Number.parseInt(data.code_id),
-            data.updated ? AbsoluteTxPosition.fromData(data.updated) : undefined,
-            data.msg
-        );
-    }
+  public static fromData(data: HistoryEntry.Data): HistoryEntry {
+    return new HistoryEntry(
+      contractCodeHistoryOperationTypeFromJSON(data.operation),
+      Number.parseInt(data.code_id),
+      data.updated ? AbsoluteTxPosition.fromData(data.updated) : undefined,
+      data.msg
+    );
+  }
 
-    public toData(): HistoryEntry.Data {
-        const res: HistoryEntry.Data = {
-            operation: contractCodeHistoryOperationTypeToJSON(this.operation),
-            code_id: this.code_id.toFixed(),
-            updated: this.updated?.toData(),
-            msg: this.msg
-        }
-        return res;
-    }
+  public toData(): HistoryEntry.Data {
+    const res: HistoryEntry.Data = {
+      operation: contractCodeHistoryOperationTypeToJSON(this.operation),
+      code_id: this.code_id.toFixed(),
+      updated: this.updated?.toData(),
+      msg: this.msg,
+    };
+    return res;
+  }
 
-    public static fromProto(proto: HistoryEntry.Proto): HistoryEntry {
-        return new HistoryEntry(
-            proto.operation,
-            proto.codeId.toNumber(),
-            proto.updated ? AbsoluteTxPosition.fromProto(proto.updated) : undefined,
-            JSON.parse(Buffer.from(proto.msg).toString('utf-8')),
-        );
-    }
+  public static fromProto(proto: HistoryEntry.Proto): HistoryEntry {
+    return new HistoryEntry(
+      proto.operation,
+      proto.codeId.toNumber(),
+      proto.updated ? AbsoluteTxPosition.fromProto(proto.updated) : undefined,
+      JSON.parse(Buffer.from(proto.msg).toString('utf-8'))
+    );
+  }
 
-    public toProto(): HistoryEntry.Proto {
-        return HistoryEntry_pb.fromPartial({
-            operation: this.operation,
-            codeId: Long.fromNumber(this.code_id),
-            updated: this.updated?.toProto(),
-            msg: Buffer.from(JSON.stringify(removeNull(this.msg)), 'utf-8'),
-        });
-    }
+  public toProto(): HistoryEntry.Proto {
+    return HistoryEntry_pb.fromPartial({
+      operation: this.operation,
+      codeId: Long.fromNumber(this.code_id),
+      updated: this.updated?.toProto(),
+      msg: Buffer.from(JSON.stringify(removeNull(this.msg)), 'utf-8'),
+    });
+  }
 }
 
 export namespace HistoryEntry {
-    export interface Amino {
-        operation: string;
-        code_id: string;
-        updated?: AbsoluteTxPosition.Amino;
-        msg: object | string;
-    }
+  export interface Amino {
+    operation: string;
+    code_id: string;
+    updated?: AbsoluteTxPosition.Amino;
+    msg: object | string;
+  }
 
-    export interface Data {
-        operation: string;
-        code_id: string;
-        updated?: AbsoluteTxPosition.Data;
-        msg: object | string;
-    }
+  export interface Data {
+    operation: string;
+    code_id: string;
+    updated?: AbsoluteTxPosition.Data;
+    msg: object | string;
+  }
 
-    export type Proto = HistoryEntry_pb;
+  export type Proto = HistoryEntry_pb;
 }

--- a/src/core/wasm/util.ts
+++ b/src/core/wasm/util.ts
@@ -1,0 +1,27 @@
+import {
+  AccessType,
+  accessTypeFromJSON,
+} from '@terra-money/terra.proto/cosmwasm/wasm/v1/types';
+
+// core v2 returns human-friendly string like 'Everybody' by wasm/type/params.go
+// but accessTypeFromJSON requires "ACCESS_TYPE_EVERYBODY"
+// this function is a wrapper to get AccessType from JSON
+export function convertAccessTypeFromJSON(accessType: string): AccessType {
+  let converted: string = accessType;
+
+  switch (accessType) {
+    case 'Everybody':
+      converted = 'ACCESS_TYPE_EVERYBODY';
+      break;
+    case 'Nobody':
+      converted = 'ACCESS_TYPE_NOBODY';
+      break;
+    case 'OnlyAddress':
+      converted = 'ACCESS_TYPE_ONLY_ADDRESS';
+      break;
+    case 'Unspecified':
+      converted = 'ACCESS_TYPE_UNSPECIFIED';
+      break;
+  }
+  return accessTypeFromJSON(converted);
+}


### PR DESCRIPTION
core v2 returns AccessType in form of human-friendly string like 'Everybody' by wasm/type/params.go
But accessTypeFromJSON requires "ACCESS_TYPE_EVERYBODY"
so wrapper function to get AccessType from human-friendly string added.