### PR TITLE
Fix issue with: "First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object."

### DIFF
--- a/src/client/lcd/api/TxAPI.ts
+++ b/src/client/lcd/api/TxAPI.ts
@@ -128,6 +128,7 @@ export interface CreateTxOptions {
   gasAdjustment?: Numeric.Input;
   feeDenoms?: string[];
   timeoutHeight?: number;
+  isClassic?: boolean;
 }
 
 export interface TxResult {


### PR DESCRIPTION
While trying to figure out the issue with posting transactions to Terra Classic from a dApp, that Terra Station also has see print screen bellow:

![Printscreen](https://uc3b8dd09a836aaf1560fb810837.previews.dropboxusercontent.com/p/thumb/ABgOkpfc_kLRH0nJhc9pPvPMmIOLV6ZcyCIv2NYRQEdpqRKkS0IKjYlgxdKW2R6pX8rMKibyeFmfM69HagjmkIpdFgSxbGZsz41o89vobPPxYmWYV9sYSTN2XFmoZ0HZqPJuo_E58qj464_T-wt3p5D_ehjRfnHldTDGkDzoMB7_xt8qtdaEJDIOR48mgS1RxnpNWabR4LaBsr3kVChZiKa78HU4_h2V9FMPz79fXjdBkBvc2FeorEwg2UrroFIxIAUfVfNC3GLESoJbhByBwx6Y2b_l0Etl7hzvLIeP_4byZZ7j5ugPjLYyjrWsB3jXXuWF3db6cByMYZykVt3C8yeUIhiEAOT-mDA_s8_O0AAVTcGgEr7rUW25ST3OGej2VZlilsAOG7ndciFQFPULiLS-/p.png)


Found out that when using `wallet-provider`/`use-wallet` package, you can pass `isClassic` as an option so that the extension can transform the transaction msgs correctly and be able to post them to the classic chain.

Like so:

```
import { useWallet } from "@terra-money/wallet-provider";

const { post } = useWallet();

const res: TxResult = await post({
  msgs,
  fee,
  // @ts-ignore
  isClassic: true,
});
```

For that reason I'm making this PR to add that option so it's actually discoverable, typescript doesn't scream saying it doesn't exist.

PS: For Terra Station to work with classic chain it needs this option passed.