### PR TITLE
Update CreateTxOptions interface for extension methods on classic

### DIFF
--- a/src/client/lcd/api/TxAPI.ts
+++ b/src/client/lcd/api/TxAPI.ts
@@ -128,6 +128,7 @@ export interface CreateTxOptions {
   gasAdjustment?: Numeric.Input;
   feeDenoms?: string[];
   timeoutHeight?: number;
+  isClassic?: boolean; // default false. set to true when you intract with terra Classic
 }
 
 export interface TxResult {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -17,7 +17,6 @@ interface Option extends CreateTxOptions {
   purgeQueue?: boolean; // default true
   sequence?: number;
   accountNumber?: number;
-  isClassic?: boolean; // default fase. set to true when you intract with terra Classic
 }
 
 interface SignBytesOption {


### PR DESCRIPTION
Since "isClassic" is declared internally, wallet-provider couldn't use methods that requires "CreateTxOptions" on classic network.
So "isClassic" needs to declare externally on "CreateTxOptions".