### PR TITLE
Allow providing isClassic to the transaction

### DIFF
--- a/src/client/lcd/api/TxAPI.ts
+++ b/src/client/lcd/api/TxAPI.ts
@@ -128,6 +128,7 @@ export interface CreateTxOptions {
   gasAdjustment?: Numeric.Input;
   feeDenoms?: string[];
   timeoutHeight?: number;
+  isClassic?: boolean;
 }
 
 export interface TxResult {


### PR DESCRIPTION
The extension.post method checks the provided data for `isClassic`, but this cannot be provided through the `post` creation (e.g. `this.wallet.post`) as `CreateTxOptions` does not allow this attribute.