### PR TITLE
Fix terra.proto imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@terra-money/terra.js",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@terra-money/terra.js",
-      "version": "3.1.6",
+      "version": "3.1.7",
       "license": "MIT",
       "dependencies": {
-        "@terra-money/legacy.proto": "npm:@terra-money/terra.proto@^0.1.7",
+        "@terra-money/legacy.proto": "file:classic-terra-terra.proto-1.1.0-rc.1.tgz",
         "@terra-money/terra.proto": "^2.1.0",
         "axios": "^0.27.2",
         "bech32": "^2.0.0",
@@ -1270,11 +1270,13 @@
       }
     },
     "node_modules/@terra-money/legacy.proto": {
-      "name": "@terra-money/terra.proto",
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@terra-money/terra.proto/-/terra.proto-0.1.7.tgz",
-      "integrity": "sha512-NXD7f6pQCulvo6+mv6MAPzhOkUzRjgYVuHZE/apih+lVnPG5hDBU0rRYnOGGofwvKT5/jQoOENnFn/gioWWnyQ==",
+      "name": "@classic-terra/terra.proto",
+      "version": "1.1.0-rc.1",
+      "resolved": "file:classic-terra-terra.proto-1.1.0-rc.1.tgz",
+      "integrity": "sha512-ffJdLJqMSUoEBqoFcEvL3HV7w1J4nUW0qxspfXXuc8bmYXOia1KGFSMATxAAHr/+CCOyVLKainpKtdFAZWqEPQ==",
+      "license": "Apache-2.0",
       "dependencies": {
+        "@improbable-eng/grpc-web": "^0.14.1",
         "google-protobuf": "^3.17.3",
         "long": "^4.0.0",
         "protobufjs": "~6.11.2"
@@ -8600,10 +8602,10 @@
       }
     },
     "@terra-money/legacy.proto": {
-      "version": "npm:@terra-money/terra.proto@0.1.7",
-      "resolved": "https://registry.npmjs.org/@terra-money/terra.proto/-/terra.proto-0.1.7.tgz",
-      "integrity": "sha512-NXD7f6pQCulvo6+mv6MAPzhOkUzRjgYVuHZE/apih+lVnPG5hDBU0rRYnOGGofwvKT5/jQoOENnFn/gioWWnyQ==",
+      "version": "file:classic-terra-terra.proto-1.1.0-rc.1.tgz",
+      "integrity": "sha512-ffJdLJqMSUoEBqoFcEvL3HV7w1J4nUW0qxspfXXuc8bmYXOia1KGFSMATxAAHr/+CCOyVLKainpKtdFAZWqEPQ==",
       "requires": {
+        "@improbable-eng/grpc-web": "^0.14.1",
         "google-protobuf": "^3.17.3",
         "long": "^4.0.0",
         "protobufjs": "~6.11.2"

--- a/src/client/lcd/APIRequester.ts
+++ b/src/client/lcd/APIRequester.ts
@@ -1,5 +1,5 @@
 import Axios, { AxiosInstance } from 'axios';
-import { OrderBy as OrderBy_pb } from '@terra-money/legacy.proto/cosmos/tx/v1beta1/service';
+import { OrderBy as OrderBy_pb } from '@terra-money/terra.proto/cosmos/tx/v1beta1/service';
 
 export type APIParams = Record<string, string | number | null | undefined>;
 

--- a/src/client/lcd/Wallet.ts
+++ b/src/client/lcd/Wallet.ts
@@ -2,8 +2,7 @@ import { LCDClient } from './LCDClient';
 import { Key } from '../../key';
 import { CreateTxOptions } from '../lcd/api/TxAPI';
 import { Tx } from '../../core/Tx';
-import { SignMode as SignModeV1 } from '@terra-money/legacy.proto/cosmos/tx/signing/v1beta1/signing';
-import { SignMode as SignModeV2 } from '@terra-money/terra.proto/cosmos/tx/signing/v1beta1/signing';
+import { SignMode } from '@terra-money/terra.proto/cosmos/tx/signing/v1beta1/signing';
 
 export class Wallet {
   constructor(public lcd: LCDClient, public key: Key) {}
@@ -53,7 +52,7 @@ export class Wallet {
     options: CreateTxOptions & {
       sequence?: number;
       accountNumber?: number;
-      signMode?: SignModeV1 | SignModeV2;
+      signMode?: SignMode;
     }
   ): Promise<Tx> {
     let accountNumber = options.accountNumber;
@@ -80,11 +79,7 @@ export class Wallet {
         accountNumber,
         sequence,
         chainID: this.lcd.config.chainID,
-        signMode:
-          options.signMode ||
-          (this.lcd.config.isClassic
-            ? SignModeV1.SIGN_MODE_DIRECT
-            : SignModeV2.SIGN_MODE_DIRECT),
+        signMode: options.signMode || SignMode.SIGN_MODE_DIRECT
       },
       this.lcd.config.isClassic
     );

--- a/src/client/lcd/api/GovAPI.ts
+++ b/src/client/lcd/api/GovAPI.ts
@@ -13,7 +13,7 @@ import {
 
 import { APIParams, Pagination, PaginationOptions } from '../APIRequester';
 import { TxSearchResult } from './TxAPI';
-import { ProposalStatus } from '@terra-money/legacy.proto/cosmos/gov/v1beta1/gov';
+import { ProposalStatus } from '@terra-money/terra.proto/cosmos/gov/v1beta1/gov';
 import { LCDClient } from '../LCDClient';
 
 export interface GovParams {

--- a/src/client/lcd/api/IbcTransferAPI.ts
+++ b/src/client/lcd/api/IbcTransferAPI.ts
@@ -1,6 +1,5 @@
 import { BaseAPI } from './BaseAPI';
 import { APIParams, Pagination, PaginationOptions } from '../APIRequester';
-//import { DenomTrace } from '@terra-money/legacy.proto/ibc/applications/transfer/v1/query'
 import { DenomTrace } from '../../../core/ibc/applications/transfer/v1/DenomTrace';
 import { LCDClient } from '../LCDClient';
 

--- a/src/client/lcd/api/StakingAPI.spec.ts
+++ b/src/client/lcd/api/StakingAPI.spec.ts
@@ -40,7 +40,7 @@ const checkDelegations = (delegations: Delegation[]) => {
 // };
 
 const delegator = test1.accAddress;
-const validator = 'terravaloper1gtw2uxdkdt3tvq790ckjz8jm8qgwkdw3uptstn';
+const validator = 'terravaloper1q8w4u2wyhx574m70gwe8km5za2ptanny9mnqy3';
 
 describe('StakingAPI', () => {
   it('parameters', async () => {

--- a/src/client/lcd/api/TendermintAPI.spec.ts
+++ b/src/client/lcd/api/TendermintAPI.spec.ts
@@ -1,6 +1,6 @@
 import { TendermintAPI } from './TendermintAPI';
 import { Tx } from '../../../core/Tx';
-import { Tx as Tx_pb } from '@terra-money/legacy.proto/cosmos/tx/v1beta1/tx';
+import { Tx as Tx_pb } from '@terra-money/terra.proto/cosmos/tx/v1beta1/tx';
 import { LCDClient } from '../LCDClient';
 
 const terra = new LCDClient({

--- a/src/client/lcd/api/TxAPI.ts
+++ b/src/client/lcd/api/TxAPI.ts
@@ -15,8 +15,7 @@ import { hashToHex } from '../../../util/hash';
 import { LCDClient } from '../LCDClient';
 import { TxLog } from '../../../core';
 import { APIParams, Pagination, PaginationOptions } from '../APIRequester';
-import { BroadcastMode as BroadcastModeV1 } from '@terra-money/legacy.proto/cosmos/tx/v1beta1/service';
-import { BroadcastMode as BroadcastModeV2 } from '@terra-money/terra.proto/cosmos/tx/v1beta1/service';
+import { BroadcastMode } from '@terra-money/terra.proto/cosmos/tx/v1beta1/service';
 
 interface Wait {
   height: number;
@@ -400,7 +399,7 @@ export class TxAPI extends BaseAPI {
 
   private async _broadcast<T>(
     tx: Tx,
-    mode: keyof typeof BroadcastModeV1 | BroadcastModeV2
+    mode: keyof typeof BroadcastMode
   ): Promise<T> {
     return await this.c.post<any>(`/cosmos/tx/v1beta1/txs`, {
       tx_bytes: this.encode(tx),

--- a/src/core/auth/Account.ts
+++ b/src/core/auth/Account.ts
@@ -1,4 +1,4 @@
-import { Any } from '@terra-money/legacy.proto/google/protobuf/any';
+import { Any } from '@terra-money/terra.proto/google/protobuf/any';
 import { BaseAccount } from './BaseAccount';
 import { LazyGradedVestingAccount } from './LazyGradedVestingAccount';
 import { ContinuousVestingAccount } from './ContinuousVestingAccount';

--- a/src/core/auth/BaseAccount.ts
+++ b/src/core/auth/BaseAccount.ts
@@ -1,8 +1,6 @@
 import { PublicKey } from '../PublicKey';
 import { JSONSerializable } from '../../util/json';
 import { AccAddress } from '../bech32';
-// import { BaseAccount as BaseAccount_pb } from '@terra-money/legacy.proto/cosmos/auth/v1beta1/auth';
-// import { Any } from '@terra-money/legacy.proto/google/protobuf/any';
 import { BaseAccount as BaseAccount_pb } from '@terra-money/terra.proto/cosmos/auth/v1beta1/auth';
 import { Any } from '@terra-money/terra.proto/google/protobuf/any';
 import * as Long from 'long';

--- a/src/core/auth/LazyGradedVestingAccount.ts
+++ b/src/core/auth/LazyGradedVestingAccount.ts
@@ -8,7 +8,7 @@ import {
   Schedule as Schedule_pb,
   VestingSchedule as VestingSchedule_pb,
 } from '@terra-money/legacy.proto/terra/vesting/v1beta1/vesting';
-import { Any } from '@terra-money/legacy.proto/google/protobuf/any';
+import { Any } from '@terra-money/terra.proto/google/protobuf/any';
 import * as Long from 'long';
 import { PublicKey } from '../PublicKey';
 

--- a/src/core/bank/msgs/MsgMultiSend.ts
+++ b/src/core/bank/msgs/MsgMultiSend.ts
@@ -1,9 +1,7 @@
 import { JSONSerializable } from '../../../util/json';
 import { Coins } from '../../Coins';
 import { AccAddress } from '../../bech32';
-import { Any } from '@terra-money/legacy.proto/google/protobuf/any';
-// there's no difference between two protos
-//import { MsgMultiSend as MsgMultiSend_legacy_pb } from '@terra-money/legacy.proto/cosmos/bank/v1beta1/tx';
+import { Any } from '@terra-money/terra.proto/google/protobuf/any';
 import { MsgMultiSend as MsgMultiSend_pb } from '@terra-money/terra.proto/cosmos/bank/v1beta1/tx';
 import {
   Input as Input_pb,

--- a/src/core/bank/msgs/MsgSend.ts
+++ b/src/core/bank/msgs/MsgSend.ts
@@ -1,9 +1,7 @@
 import { Coins } from '../../Coins';
 import { JSONSerializable } from '../../../util/json';
 import { AccAddress } from '../../bech32';
-import { Any } from '@terra-money/legacy.proto/google/protobuf/any';
-// there's no difference between two protos
-//import { MsgSend as MsgSend_legacy_pb } from '@terra-money/legacy.proto/cosmos/bank/v1beta1/tx';
+import { Any } from '@terra-money/terra.proto/google/protobuf/any';
 import { MsgSend as MsgSend_pb } from '@terra-money/terra.proto/cosmos/bank/v1beta1/tx';
 
 /**

--- a/src/core/crisis/MsgVerifyInvariant.ts
+++ b/src/core/crisis/MsgVerifyInvariant.ts
@@ -1,6 +1,5 @@
 import { JSONSerializable } from '../../util/json';
-import { Any } from '@terra-money/legacy.proto/google/protobuf/any';
-//import { MsgVerifyInvariant as MsgVerifyInvariant_pb } from '@terra-money/legacy.proto/cosmos/crisis/v1beta1/tx';
+import { Any } from '@terra-money/terra.proto/google/protobuf/any';
 import { MsgVerifyInvariant as MsgVerifyInvariant_pb } from '@terra-money/terra.proto/cosmos/crisis/v1beta1/tx';
 import { AccAddress } from '../bech32';
 

--- a/src/core/distribution/msgs/MsgFundCommunityPool.ts
+++ b/src/core/distribution/msgs/MsgFundCommunityPool.ts
@@ -2,8 +2,6 @@ import { JSONSerializable } from '../../../util/json';
 import { AccAddress } from '../../bech32';
 import { Coins } from '../../Coins';
 import { Any } from '@terra-money/terra.proto/google/protobuf/any';
-// there's no difference between two protos
-// import { MsgFundCommunityPool as MsgFundCommunityPool_legacy_pb } from '@terra-money/legacy.proto/cosmos/distribution/v1beta1/tx';
 import { MsgFundCommunityPool as MsgFundCommunityPool_pb } from '@terra-money/terra.proto/cosmos/distribution/v1beta1/tx';
 
 export class MsgFundCommunityPool extends JSONSerializable<

--- a/src/core/distribution/msgs/MsgSetWithdrawAddress.ts
+++ b/src/core/distribution/msgs/MsgSetWithdrawAddress.ts
@@ -1,8 +1,6 @@
 import { JSONSerializable } from '../../../util/json';
 import { AccAddress } from '../../bech32';
 import { Any } from '@terra-money/terra.proto/google/protobuf/any';
-// there's no difference between two protos
-// import { MsgSetWithdrawAddress as MsgSetWithdrawAddress_legacy_pb } from '@terra-money/legacy.proto/cosmos/distribution/v1beta1/tx';
 import { MsgSetWithdrawAddress as MsgSetWithdrawAddress_pb } from '@terra-money/terra.proto/cosmos/distribution/v1beta1/tx';
 
 /**

--- a/src/core/distribution/msgs/MsgWithdrawDelegatorReward.ts
+++ b/src/core/distribution/msgs/MsgWithdrawDelegatorReward.ts
@@ -1,8 +1,6 @@
 import { JSONSerializable } from '../../../util/json';
 import { AccAddress, ValAddress } from '../../bech32';
 import { Any } from '@terra-money/terra.proto/google/protobuf/any';
-// there's no difference between two protos
-// import { MsgWithdrawDelegatorReward as MsgWithdrawDelegatorReward_legacy_pb } from '@terra-money/legacy.proto/cosmos/distribution/v1beta1/tx';
 import { MsgWithdrawDelegatorReward as MsgWithdrawDelegatorReward_pb } from '@terra-money/terra.proto/cosmos/distribution/v1beta1/tx';
 
 /**

--- a/src/core/distribution/msgs/MsgWithdrawValidatorCommission.ts
+++ b/src/core/distribution/msgs/MsgWithdrawValidatorCommission.ts
@@ -1,7 +1,7 @@
 import { JSONSerializable } from '../../../util/json';
 import { ValAddress } from '../../bech32';
 import { Any } from '@terra-money/terra.proto/google/protobuf/any';
-import { MsgWithdrawValidatorCommission as MsgWithdrawValidatorCommission_pb } from '@terra-money/legacy.proto/cosmos/distribution/v1beta1/tx';
+import { MsgWithdrawValidatorCommission as MsgWithdrawValidatorCommission_pb } from '@terra-money/terra.proto/cosmos/distribution/v1beta1/tx';
 
 /**
  * A validator can withdraw their outstanding commission rewards accrued from all

--- a/src/core/distribution/proposals/CommunityPoolSpendProposal.ts
+++ b/src/core/distribution/proposals/CommunityPoolSpendProposal.ts
@@ -1,9 +1,7 @@
 import { JSONSerializable } from '../../../util/json';
 import { Coins } from '../../Coins';
 import { AccAddress } from '../../bech32';
-import { Any } from '@terra-money/legacy.proto/google/protobuf/any';
-// there's no difference between two protos
-// import { CommunityPoolSpendProposal as CommunityPoolSpendProposal_legacy_pb } from '@terra-money/legacy.proto/cosmos/distribution/v1beta1/distribution';
+import { Any } from '@terra-money/terra.proto/google/protobuf/any';
 import { CommunityPoolSpendProposal as CommunityPoolSpendProposal_pb } from '@terra-money/terra.proto/cosmos/distribution/v1beta1/distribution';
 
 /**

--- a/src/core/feegrant/allowances/index.ts
+++ b/src/core/feegrant/allowances/index.ts
@@ -5,7 +5,7 @@ import { AllowedMsgAllowance } from './AllowedMsgAllowance';
 export * from './BasicAllowance';
 export * from './PeriodicAllowance';
 export * from './AllowedMsgAllowance';
-import { Any } from '@terra-money/legacy.proto/google/protobuf/any';
+import { Any } from '@terra-money/terra.proto/google/protobuf/any';
 
 export type Allowance =
   | BasicAllowance

--- a/src/core/ibc/applications/transfer/v1/DenomTrace.ts
+++ b/src/core/ibc/applications/transfer/v1/DenomTrace.ts
@@ -1,4 +1,4 @@
-import { DenomTrace as DenomTrace_pb } from '@terra-money/legacy.proto/ibc/applications/transfer/v1/transfer';
+import { DenomTrace as DenomTrace_pb } from '@terra-money/terra.proto/ibc/applications/transfer/v1/transfer';
 import { JSONSerializable } from '../../../../../util/json';
 
 /**

--- a/src/core/market/msgs/MsgSwap.ts
+++ b/src/core/market/msgs/MsgSwap.ts
@@ -3,7 +3,7 @@ import { Coin } from '../../Coin';
 import { Denom } from '../../Denom';
 import { AccAddress } from '../../bech32';
 import { MsgSwap as MsgSwap_pb } from '@terra-money/legacy.proto/terra/market/v1beta1/tx';
-import { Any } from '@terra-money/legacy.proto/google/protobuf/any';
+import { Any } from '@terra-money/terra.proto/google/protobuf/any';
 
 /**
  * Executes a market swap between 2 denominations at the exchange rate registered by the

--- a/src/core/market/msgs/MsgSwapSend.ts
+++ b/src/core/market/msgs/MsgSwapSend.ts
@@ -2,7 +2,7 @@ import { JSONSerializable } from '../../../util/json';
 import { Coin } from '../../Coin';
 import { Denom } from '../../Denom';
 import { AccAddress } from '../../bech32';
-import { Any } from '@terra-money/legacy.proto/google/protobuf/any';
+import { Any } from '@terra-money/terra.proto/google/protobuf/any';
 import { MsgSwapSend as MsgSwapSend_pb } from '@terra-money/legacy.proto/terra/market/v1beta1/tx';
 
 /**

--- a/src/core/oracle/msgs/MsgAggregateExchangeRatePrevote.ts
+++ b/src/core/oracle/msgs/MsgAggregateExchangeRatePrevote.ts
@@ -1,6 +1,6 @@
 import { JSONSerializable } from '../../../util/json';
 import { AccAddress, ValAddress } from '../../bech32';
-import { Any } from '@terra-money/legacy.proto/google/protobuf/any';
+import { Any } from '@terra-money/terra.proto/google/protobuf/any';
 import { MsgAggregateExchangeRatePrevote as MsgAggregateExchangeRatePrevote_pb } from '@terra-money/legacy.proto/terra/oracle/v1beta1/tx';
 
 /**

--- a/src/core/oracle/msgs/MsgAggregateExchangeRateVote.ts
+++ b/src/core/oracle/msgs/MsgAggregateExchangeRateVote.ts
@@ -3,7 +3,7 @@ import { JSONSerializable } from '../../../util/json';
 import { AccAddress, ValAddress } from '../../bech32';
 import { MsgAggregateExchangeRatePrevote } from './MsgAggregateExchangeRatePrevote';
 import { Coins } from '../../Coins';
-import { Any } from '@terra-money/legacy.proto/google/protobuf/any';
+import { Any } from '@terra-money/terra.proto/google/protobuf/any';
 import { MsgAggregateExchangeRateVote as MsgAggregateExchangeRateVote_pb } from '@terra-money/legacy.proto/terra/oracle/v1beta1/tx';
 
 /**

--- a/src/core/params/ParamChange.ts
+++ b/src/core/params/ParamChange.ts
@@ -1,5 +1,5 @@
 import { JSONSerializable } from '../../util/json';
-import { ParamChange as ParamChange_pb } from '@terra-money/legacy.proto/cosmos/params/v1beta1/params';
+import { ParamChange as ParamChange_pb } from '@terra-money/terra.proto/cosmos/params/v1beta1/params';
 
 export class ParamChanges extends JSONSerializable<
   ParamChanges.Amino,

--- a/src/core/staking/msgs/MsgBeginRedelegate.ts
+++ b/src/core/staking/msgs/MsgBeginRedelegate.ts
@@ -1,8 +1,6 @@
 import { JSONSerializable } from '../../../util/json';
 import { Coin } from '../../Coin';
 import { AccAddress, ValAddress } from '../../bech32';
-// import { Any } from '@terra-money/legacy.proto/google/protobuf/any';
-// import { MsgBeginRedelegate as MsgBeginRedelegate_pb } from '@terra-money/legacy.proto/cosmos/staking/v1beta1/tx';
 import { Any } from '@terra-money/terra.proto/google/protobuf/any';
 import { MsgBeginRedelegate as MsgBeginRedelegate_pb } from '@terra-money/terra.proto/cosmos/staking/v1beta1/tx';
 /**

--- a/src/core/staking/msgs/MsgCreateValidator.ts
+++ b/src/core/staking/msgs/MsgCreateValidator.ts
@@ -3,8 +3,6 @@ import { Coin } from '../../Coin';
 import { Int } from '../../numeric';
 import { AccAddress, ValAddress } from '../../bech32';
 import { Validator } from '../Validator';
-// import { Any } from '@terra-money/legacy.proto/google/protobuf/any';
-// import { MsgCreateValidator as MsgCreateValidator_pb } from '@terra-money/legacy.proto/cosmos/staking/v1beta1/tx';
 import { Any } from '@terra-money/terra.proto/google/protobuf/any';
 import { MsgCreateValidator as MsgCreateValidator_pb } from '@terra-money/terra.proto/cosmos/staking/v1beta1/tx';
 import { ValConsPublicKey, PublicKey } from '../../PublicKey';

--- a/src/core/staking/msgs/MsgDelegate.ts
+++ b/src/core/staking/msgs/MsgDelegate.ts
@@ -1,8 +1,6 @@
 import { Coin } from '../../Coin';
 import { JSONSerializable } from '../../../util/json';
 import { AccAddress, ValAddress } from '../../bech32';
-// import { Any } from '@terra-money/legacy.proto/google/protobuf/any';
-// import { MsgDelegate as MsgDelegate_pb } from '@terra-money/legacy.proto/cosmos/staking/v1beta1/tx';
 import { Any } from '@terra-money/terra.proto/google/protobuf/any';
 import { MsgDelegate as MsgDelegate_pb } from '@terra-money/terra.proto/cosmos/staking/v1beta1/tx';
 /**

--- a/src/core/staking/msgs/MsgEditValidator.ts
+++ b/src/core/staking/msgs/MsgEditValidator.ts
@@ -2,8 +2,6 @@ import { JSONSerializable } from '../../../util/json';
 import { Dec, Int } from '../../numeric';
 import { ValAddress } from '../../bech32';
 import { Validator } from '../Validator';
-// import { Any } from '@terra-money/legacy.proto/google/protobuf/any';
-// import { MsgEditValidator as MsgEditValidator_pb } from '@terra-money/legacy.proto/cosmos/staking/v1beta1/tx';
 import { Any } from '@terra-money/terra.proto/google/protobuf/any';
 import { MsgEditValidator as MsgEditValidator_pb } from '@terra-money/terra.proto/cosmos/staking/v1beta1/tx';
 

--- a/src/core/staking/msgs/MsgUndelegate.ts
+++ b/src/core/staking/msgs/MsgUndelegate.ts
@@ -1,8 +1,6 @@
 import { Coin } from '../../Coin';
 import { JSONSerializable } from '../../../util/json';
 import { AccAddress, ValAddress } from '../../bech32';
-// import { Any } from '@terra-money/legacy.proto/google/protobuf/any';
-// import { MsgUndelegate as MsgUndelegate_pb } from '@terra-money/legacy.proto/cosmos/staking/v1beta1/tx';
 import { Any } from '@terra-money/terra.proto/google/protobuf/any';
 import { MsgUndelegate as MsgUndelegate_pb } from '@terra-money/terra.proto/cosmos/staking/v1beta1/tx';
 

--- a/src/core/upgrade/proposals/CancelSoftwareUpgradeProposal.ts
+++ b/src/core/upgrade/proposals/CancelSoftwareUpgradeProposal.ts
@@ -1,6 +1,6 @@
 import { JSONSerializable } from '../../../util/json';
-import { Any } from '@terra-money/legacy.proto/google/protobuf/any';
-import { CancelSoftwareUpgradeProposal as CancelSoftwareUpgradeProposal_pb } from '@terra-money/legacy.proto/cosmos/upgrade/v1beta1/upgrade';
+import { Any } from '@terra-money/terra.proto/google/protobuf/any';
+import { CancelSoftwareUpgradeProposal as CancelSoftwareUpgradeProposal_pb } from '@terra-money/terra.proto/cosmos/upgrade/v1beta1/upgrade';
 
 /**
  *  CancelSoftwareUpgradeProposal is a gov Content type for cancelling a software upgrade

--- a/src/core/upgrade/proposals/SoftwareUpgradeProposal.ts
+++ b/src/core/upgrade/proposals/SoftwareUpgradeProposal.ts
@@ -1,6 +1,6 @@
 import { JSONSerializable } from '../../../util/json';
-import { Any } from '@terra-money/legacy.proto/google/protobuf/any';
-import { SoftwareUpgradeProposal as SoftwareUpgradeProposal_pb } from '@terra-money/legacy.proto/cosmos/upgrade/v1beta1/upgrade';
+import { Any } from '@terra-money/terra.proto/google/protobuf/any';
+import { SoftwareUpgradeProposal as SoftwareUpgradeProposal_pb } from '@terra-money/terra.proto/cosmos/upgrade/v1beta1/upgrade';
 import { Plan } from '../Plan';
 
 /**

--- a/src/core/wasm/proposals/StoreCodeProposal.ts
+++ b/src/core/wasm/proposals/StoreCodeProposal.ts
@@ -1,6 +1,6 @@
 import { JSONSerializable } from '../../../util/json';
 import { AccAddress } from '../../bech32';
-import { Any } from '@terra-money/legacy.proto/google/protobuf/any';
+import { Any } from '@terra-money/terra.proto/google/protobuf/any';
 import { StoreCodeProposal as StoreCodeProposal_pb } from '@terra-money/terra.proto/cosmwasm/wasm/v1/proposal';
 import { AccessConfig } from '../AccessConfig';
 


### PR DESCRIPTION
This is a housekeeping PR for replacing legacy.proto to terra.proto where terra.proto should be used. The reason why there was nothing wrong with using legacy.proto was that it actually had the exact same structure as terra.proto.