### PR TITLE
Feat: Support WASM Proposal Types and API (Minimal)

### DIFF
--- a/src/client/lcd/api/WasmAPI.ts
+++ b/src/client/lcd/api/WasmAPI.ts
@@ -111,16 +111,6 @@ export class WasmAPI extends BaseAPI {
     codeID: number,
     params: APIParams = {}
   ): Promise<CodeInfo> {
-    if (this.lcd.config.isClassic) {
-      const endpoint = `/terra/wasm/v1beta1/codes/${codeID}`;
-      return this.c
-        .get<{ code_info: CodeInfo.DataV1 }>(endpoint, params)
-        .then(({ code_info: d }) => ({
-          code_id: Number.parseInt(d.code_id),
-          code_hash: d.code_hash,
-          creator: d.creator,
-        }));
-    }
     const endpoint = `/cosmwasm/wasm/v1/code/${codeID}`;
 
     return this.c
@@ -139,19 +129,6 @@ export class WasmAPI extends BaseAPI {
     contractAddress: AccAddress,
     params: APIParams = {}
   ): Promise<ContractInfo> {
-    if (this.lcd.config.isClassic) {
-      const endpoint = `/terra/wasm/v1beta1/contracts/${contractAddress}`;
-      return this.c
-        .get<{ contract_info: ContractInfo.DataV1 }>(endpoint, params)
-        .then(({ contract_info: d }) => ({
-          code_id: Number.parseInt(d.code_id),
-          address: d.address,
-          creator: d.creator,
-          admin: d.admin !== '' ? d.admin : undefined,
-          init_msg: d.init_msg,
-        }));
-    }
-
     // new endpoint doesn't return init_msg so have to retrieve it from history
     const [historyEntry] = await this.contractHistory(contractAddress);
 
@@ -175,33 +152,18 @@ export class WasmAPI extends BaseAPI {
     query: object | string,
     params: APIParams = {}
   ): Promise<T> {
-    if (this.lcd.config.isClassic) {
-      const endpoint = `/terra/wasm/v1beta1/contracts/${contractAddress}/store`;
-      return this.c
-        .get<{ query_result: T }>(endpoint, {
-          ...params,
-          query_msg: Buffer.from(JSON.stringify(query), 'utf-8').toString(
-            'base64'
-          ),
-        })
-        .then(d => d.query_result);
-    } else {
-      const query_msg = Buffer.from(JSON.stringify(query), 'utf-8').toString(
-        'base64'
-      );
-      const endpoint = `/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${query_msg}`;
-      return this.c
-        .get<{ data: T }>(endpoint, {
-          ...params,
-        })
-        .then(d => d.data);
-    }
+    const query_msg = Buffer.from(JSON.stringify(query), 'utf-8').toString(
+      'base64'
+    );
+    const endpoint = `/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${query_msg}`;
+    return this.c
+      .get<{ data: T }>(endpoint, {
+        ...params,
+      })
+      .then(d => d.data);
   }
 
   public async parameters(params: APIParams = {}): Promise<WasmParams> {
-    if (!this.lcd.config.isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return this.c
       .get<{ params: WasmParams.Data }>(`/terra/wasm/v1beta1/params`, params)
       .then(({ params: d }) => ({
@@ -212,9 +174,6 @@ export class WasmAPI extends BaseAPI {
   }
 
   public async pinnedCodes(params: APIParams = {}): Promise<PinnedCodes> {
-    if (this.lcd.config.isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return this.c
       .get<{ pinned_code: PinnedCodes.Data }>(
         `/cosmwasm/wasm/v1/codes/pinned`,
@@ -230,9 +189,6 @@ export class WasmAPI extends BaseAPI {
     query_data: string,
     params: APIParams = {}
   ): Promise<QueryResult> {
-    if (this.lcd.config.isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return this.c
       .get<{ result: QueryResult.Data }>(
         `/cosmwasm/wasm/v1/contract/${contractAddress}/raw/${Buffer.from(
@@ -251,9 +207,6 @@ export class WasmAPI extends BaseAPI {
     query_data: object | string,
     params: APIParams = {}
   ): Promise<QueryResult> {
-    if (this.lcd.config.isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return this.c
       .get<{ result: QueryResult.Data }>(
         `/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${Buffer.from(
@@ -271,9 +224,6 @@ export class WasmAPI extends BaseAPI {
     contractAddress: AccAddress,
     params: Partial<PaginationOptions & APIParams> = {}
   ): Promise<[HistoryEntry[], Pagination]> {
-    if (this.lcd.config.isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return this.c
       .get<{
         entries: HistoryEntry.Data[];
@@ -289,9 +239,6 @@ export class WasmAPI extends BaseAPI {
     contractAddress: AccAddress,
     params: Partial<PaginationOptions & APIParams> = {}
   ): Promise<[Model[], Pagination]> {
-    if (this.lcd.config.isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return this.c
       .get<{
         models: Model.Data[];
@@ -311,9 +258,6 @@ export class WasmAPI extends BaseAPI {
   public async allCodes(
     params: Partial<PaginationOptions & APIParams> = {}
   ): Promise<[CodeInfo[], Pagination]> {
-    if (this.lcd.config.isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return this.c
       .get<{
         codeInfos: CodeInfo.DataV2[];

--- a/src/core/wasm/proposals/ClearAdminProposal.ts
+++ b/src/core/wasm/proposals/ClearAdminProposal.ts
@@ -27,21 +27,15 @@ export class ClearAdminProposal extends JSONSerializable<
 
   public static fromAmino(
     data: ClearAdminProposal.Amino,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): ClearAdminProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     const {
       value: { title, description, contract },
     } = data as ClearAdminProposal.Amino;
     return new ClearAdminProposal(title, description, contract);
   }
 
-  public toAmino(isClassic?: boolean): ClearAdminProposal.Amino {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toAmino(_isClassic?: boolean): ClearAdminProposal.Amino {
     const { title, description, contract } = this;
     return {
       type: 'wasm/ClearAdminProposal',
@@ -55,11 +49,8 @@ export class ClearAdminProposal extends JSONSerializable<
 
   public static fromProto(
     proto: ClearAdminProposal.Proto,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): ClearAdminProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return new ClearAdminProposal(
       proto.title,
       proto.description,
@@ -67,10 +58,7 @@ export class ClearAdminProposal extends JSONSerializable<
     );
   }
 
-  public toProto(isClassic?: boolean): ClearAdminProposal.Proto {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toProto(_isClassic?: boolean): ClearAdminProposal.Proto {
     const { title, description, contract } = this;
     return ClearAdminProposal_pb.fromPartial({
       title,
@@ -79,9 +67,6 @@ export class ClearAdminProposal extends JSONSerializable<
     });
   }
   public packAny(isClassic?: boolean): Any {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return Any.fromPartial({
       typeUrl: '/cosmwasm.wasm.v1.ClearAdminProposal',
       value: ClearAdminProposal_pb.encode(this.toProto(isClassic)).finish(),
@@ -92,9 +77,6 @@ export class ClearAdminProposal extends JSONSerializable<
     msgAny: Any,
     isClassic?: boolean
   ): ClearAdminProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return ClearAdminProposal.fromProto(
       ClearAdminProposal_pb.decode(msgAny.value),
       isClassic
@@ -103,19 +85,13 @@ export class ClearAdminProposal extends JSONSerializable<
 
   public static fromData(
     data: ClearAdminProposal.Data,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): ClearAdminProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     const { title, description, contract } = data as ClearAdminProposal.Data;
     return new ClearAdminProposal(title, description, contract);
   }
 
-  public toData(isClassic?: boolean): ClearAdminProposal.Data {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toData(_isClassic?: boolean): ClearAdminProposal.Data {
     const { title, description, contract } = this;
     return {
       '@type': '/cosmwasm.wasm.v1.ClearAdminProposal',

--- a/src/core/wasm/proposals/ExecuteContractProposal.ts
+++ b/src/core/wasm/proposals/ExecuteContractProposal.ts
@@ -37,11 +37,8 @@ export class ExecuteContractProposal extends JSONSerializable<
 
   public static fromAmino(
     data: ExecuteContractProposal.Amino,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): ExecuteContractProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     const {
       value: { title, description, run_as, contract, msg, funds },
     } = data as ExecuteContractProposal.Amino;
@@ -55,11 +52,8 @@ export class ExecuteContractProposal extends JSONSerializable<
     );
   }
 
-  public toAmino(isClassic?: boolean): ExecuteContractProposal.Amino {
+  public toAmino(_isClassic?: boolean): ExecuteContractProposal.Amino {
     const { title, description, run_as, contract, execute_msg, coins } = this;
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return {
       type: 'wasm/ExecuteContractProposal',
       value: {
@@ -75,11 +69,8 @@ export class ExecuteContractProposal extends JSONSerializable<
 
   public static fromProto(
     proto: ExecuteContractProposal.Proto,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): ExecuteContractProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return new ExecuteContractProposal(
       proto.title,
       proto.description,
@@ -90,33 +81,25 @@ export class ExecuteContractProposal extends JSONSerializable<
     );
   }
 
-  public toProto(isClassic?: boolean): ExecuteContractProposal.Proto {
+  public toProto(_isClassic?: boolean): ExecuteContractProposal.Proto {
     const { title, description, run_as, contract, execute_msg, coins } = this;
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    } else {
-      return ExecuteContractProposal_pb.fromPartial({
-        title,
-        description,
-        funds: coins.toProto(),
-        contract,
-        runAs: run_as,
-        msg: Buffer.from(JSON.stringify(removeNull(execute_msg)), 'utf-8'),
-      });
-    }
+    return ExecuteContractProposal_pb.fromPartial({
+      title,
+      description,
+      funds: coins.toProto(),
+      contract,
+      runAs: run_as,
+      msg: Buffer.from(JSON.stringify(removeNull(execute_msg)), 'utf-8'),
+    });
   }
 
   public packAny(isClassic?: boolean): Any {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    } else {
-      return Any.fromPartial({
-        typeUrl: '/cosmwasm.wasm.v1.ExecuteContractProposal',
-        value: ExecuteContractProposal_pb.encode(
-          this.toProto(isClassic)
-        ).finish(),
-      });
-    }
+    return Any.fromPartial({
+      typeUrl: '/cosmwasm.wasm.v1.ExecuteContractProposal',
+      value: ExecuteContractProposal_pb.encode(
+        this.toProto(isClassic)
+      ).finish(),
+    });
   }
 
   public static unpackAny(
@@ -131,11 +114,8 @@ export class ExecuteContractProposal extends JSONSerializable<
 
   public static fromData(
     data: ExecuteContractProposal.Data,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): ExecuteContractProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     const { title, description, run_as, contract, msg, funds } =
       data as ExecuteContractProposal.Data;
     return new ExecuteContractProposal(
@@ -148,21 +128,17 @@ export class ExecuteContractProposal extends JSONSerializable<
     );
   }
 
-  public toData(isClassic?: boolean): ExecuteContractProposal.Data {
+  public toData(_isClassic?: boolean): ExecuteContractProposal.Data {
     const { title, description, run_as, contract, execute_msg, coins } = this;
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    } else {
-      return {
-        '@type': '/cosmwasm.wasm.v1.ExecuteContractProposal',
-        title,
-        description,
-        run_as,
-        contract,
-        msg: execute_msg,
-        funds: coins.toData(),
-      };
-    }
+    return {
+      '@type': '/cosmwasm.wasm.v1.ExecuteContractProposal',
+      title,
+      description,
+      run_as,
+      contract,
+      msg: execute_msg,
+      funds: coins.toData(),
+    };
   }
 }
 

--- a/src/core/wasm/proposals/InstantiateContractProposal.ts
+++ b/src/core/wasm/proposals/InstantiateContractProposal.ts
@@ -42,11 +42,8 @@ export class InstantiateContractProposal extends JSONSerializable<
 
   public static fromAmino(
     data: InstantiateContractProposal.Amino,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): InstantiateContractProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     const {
       value: { title, description, run_as, admin, code_id, msg, funds, label },
     } = data as InstantiateContractProposal.Amino;
@@ -62,7 +59,7 @@ export class InstantiateContractProposal extends JSONSerializable<
     );
   }
 
-  public toAmino(isClassic?: boolean): InstantiateContractProposal.Amino {
+  public toAmino(_isClassic?: boolean): InstantiateContractProposal.Amino {
     const {
       title,
       description,
@@ -73,9 +70,6 @@ export class InstantiateContractProposal extends JSONSerializable<
       init_coins,
       label,
     } = this;
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return {
       type: 'wasm/InstantiateContractProposal',
       value: {
@@ -93,11 +87,8 @@ export class InstantiateContractProposal extends JSONSerializable<
 
   public static fromProto(
     proto: InstantiateContractProposal.Proto,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): InstantiateContractProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return new InstantiateContractProposal(
       proto.title,
       proto.description,
@@ -110,7 +101,7 @@ export class InstantiateContractProposal extends JSONSerializable<
     );
   }
 
-  public toProto(isClassic?: boolean): InstantiateContractProposal.Proto {
+  public toProto(_isClassic?: boolean): InstantiateContractProposal.Proto {
     const {
       title,
       description,
@@ -121,9 +112,6 @@ export class InstantiateContractProposal extends JSONSerializable<
       init_coins,
       label,
     } = this;
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return InstantiateContractProposal_pb.fromPartial({
       title,
       description,
@@ -137,9 +125,6 @@ export class InstantiateContractProposal extends JSONSerializable<
   }
 
   public packAny(isClassic?: boolean): Any {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return Any.fromPartial({
       typeUrl: '/cosmwasm.wasm.v1.InstantiateContractProposal',
       value: InstantiateContractProposal_pb.encode(
@@ -152,9 +137,6 @@ export class InstantiateContractProposal extends JSONSerializable<
     msgAny: Any,
     isClassic?: boolean
   ): InstantiateContractProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return InstantiateContractProposal.fromProto(
       InstantiateContractProposal_pb.decode(msgAny.value),
       isClassic
@@ -163,11 +145,8 @@ export class InstantiateContractProposal extends JSONSerializable<
 
   public static fromData(
     data: InstantiateContractProposal.Data,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): InstantiateContractProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     const { title, description, run_as, admin, code_id, label, msg, funds } =
       data as InstantiateContractProposal.Data;
     return new InstantiateContractProposal(
@@ -182,7 +161,7 @@ export class InstantiateContractProposal extends JSONSerializable<
     );
   }
 
-  public toData(isClassic?: boolean): InstantiateContractProposal.Data {
+  public toData(_isClassic?: boolean): InstantiateContractProposal.Data {
     const {
       title,
       description,
@@ -193,9 +172,6 @@ export class InstantiateContractProposal extends JSONSerializable<
       init_msg,
       init_coins,
     } = this;
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return {
       '@type': '/cosmwasm.wasm.v1.InstantiateContractProposal',
       title,

--- a/src/core/wasm/proposals/MigrateContractProposal.ts
+++ b/src/core/wasm/proposals/MigrateContractProposal.ts
@@ -29,11 +29,8 @@ export class MigrateContractProposal extends JSONSerializable<
 
   public static fromAmino(
     data: MigrateContractProposal.Amino,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): MigrateContractProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     const {
       value: { title, description, contract, code_id, msg },
     } = data as MigrateContractProposal.Amino;
@@ -46,10 +43,7 @@ export class MigrateContractProposal extends JSONSerializable<
     );
   }
 
-  public toAmino(isClassic?: boolean): MigrateContractProposal.Amino {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toAmino(_isClassic?: boolean): MigrateContractProposal.Amino {
     const { title, description, contract, new_code_id, migrate_msg } = this;
     return {
       type: 'wasm/MigrateContractProposal',
@@ -65,11 +59,8 @@ export class MigrateContractProposal extends JSONSerializable<
 
   public static fromProto(
     proto: MigrateContractProposal.Proto,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): MigrateContractProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return new MigrateContractProposal(
       proto.title,
       proto.description,
@@ -79,10 +70,7 @@ export class MigrateContractProposal extends JSONSerializable<
     );
   }
 
-  public toProto(isClassic?: boolean): MigrateContractProposal.Proto {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toProto(_isClassic?: boolean): MigrateContractProposal.Proto {
     const { title, description, contract, new_code_id, migrate_msg } = this;
     return MigrateContractProposal_pb.fromPartial({
       title,
@@ -93,9 +81,6 @@ export class MigrateContractProposal extends JSONSerializable<
     });
   }
   public packAny(isClassic?: boolean): Any {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return Any.fromPartial({
       typeUrl: '/cosmwasm.wasm.v1.MigrateContractProposal',
       value: MigrateContractProposal_pb.encode(
@@ -108,9 +93,6 @@ export class MigrateContractProposal extends JSONSerializable<
     msgAny: Any,
     isClassic?: boolean
   ): MigrateContractProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return MigrateContractProposal.fromProto(
       MigrateContractProposal_pb.decode(msgAny.value),
       isClassic
@@ -119,11 +101,8 @@ export class MigrateContractProposal extends JSONSerializable<
 
   public static fromData(
     data: MigrateContractProposal.Data,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): MigrateContractProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     const { title, description, contract, code_id, msg } =
       data as MigrateContractProposal.Data;
     return new MigrateContractProposal(
@@ -135,10 +114,7 @@ export class MigrateContractProposal extends JSONSerializable<
     );
   }
 
-  public toData(isClassic?: boolean): MigrateContractProposal.Data {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toData(_isClassic?: boolean): MigrateContractProposal.Data {
     const { title, description, contract, new_code_id, migrate_msg } = this;
     return {
       '@type': '/cosmwasm.wasm.v1.MigrateContractProposal',

--- a/src/core/wasm/proposals/PinCodesProposal.ts
+++ b/src/core/wasm/proposals/PinCodesProposal.ts
@@ -27,11 +27,8 @@ export class PinCodesProposal extends JSONSerializable<
 
   public static fromAmino(
     data: PinCodesProposal.Amino,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): PinCodesProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     const {
       value: { title, description, code_ids },
     } = data as PinCodesProposal.Amino;
@@ -42,10 +39,7 @@ export class PinCodesProposal extends JSONSerializable<
     );
   }
 
-  public toAmino(isClassic?: boolean): PinCodesProposal.Amino {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toAmino(_isClassic?: boolean): PinCodesProposal.Amino {
     const { title, description, code_ids } = this;
     return {
       type: 'wasm/PinCodesProposal',
@@ -59,11 +53,8 @@ export class PinCodesProposal extends JSONSerializable<
 
   public static fromProto(
     proto: PinCodesProposal.Proto,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): PinCodesProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return new PinCodesProposal(
       proto.title,
       proto.description,
@@ -71,10 +62,7 @@ export class PinCodesProposal extends JSONSerializable<
     );
   }
 
-  public toProto(isClassic?: boolean): PinCodesProposal.Proto {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toProto(_isClassic?: boolean): PinCodesProposal.Proto {
     const { title, description, code_ids } = this;
     return PinCodesProposal_pb.fromPartial({
       title,
@@ -83,9 +71,6 @@ export class PinCodesProposal extends JSONSerializable<
     });
   }
   public packAny(isClassic?: boolean): Any {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return Any.fromPartial({
       typeUrl: '/cosmwasm.wasm.v1.PinCodesProposal',
       value: PinCodesProposal_pb.encode(this.toProto(isClassic)).finish(),
@@ -93,9 +78,6 @@ export class PinCodesProposal extends JSONSerializable<
   }
 
   public static unpackAny(msgAny: Any, isClassic?: boolean): PinCodesProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return PinCodesProposal.fromProto(
       PinCodesProposal_pb.decode(msgAny.value),
       isClassic
@@ -104,11 +86,8 @@ export class PinCodesProposal extends JSONSerializable<
 
   public static fromData(
     data: PinCodesProposal.Data,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): PinCodesProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     const { title, description, code_ids } = data as PinCodesProposal.Data;
     return new PinCodesProposal(
       title,
@@ -117,10 +96,7 @@ export class PinCodesProposal extends JSONSerializable<
     );
   }
 
-  public toData(isClassic?: boolean): PinCodesProposal.Data {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toData(_isClassic?: boolean): PinCodesProposal.Data {
     const { title, description, code_ids } = this;
     return {
       '@type': '/cosmwasm.wasm.v1.PinCodesProposal',

--- a/src/core/wasm/proposals/StoreCodeProposal.ts
+++ b/src/core/wasm/proposals/StoreCodeProposal.ts
@@ -31,11 +31,8 @@ export class StoreCodeProposal extends JSONSerializable<
 
   public static fromAmino(
     data: StoreCodeProposal.Amino,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): StoreCodeProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     const {
       value: {
         title,
@@ -56,10 +53,7 @@ export class StoreCodeProposal extends JSONSerializable<
     );
   }
 
-  public toAmino(isClassic?: boolean): StoreCodeProposal.Amino {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toAmino(_isClassic?: boolean): StoreCodeProposal.Amino {
     const {
       title,
       description,
@@ -81,11 +75,8 @@ export class StoreCodeProposal extends JSONSerializable<
 
   public static fromData(
     data: StoreCodeProposal.Data,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): StoreCodeProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     const {
       title,
       description,
@@ -104,10 +95,7 @@ export class StoreCodeProposal extends JSONSerializable<
     );
   }
 
-  public toData(isClassic?: boolean): StoreCodeProposal.Data {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toData(_isClassic?: boolean): StoreCodeProposal.Data {
     const {
       title,
       description,
@@ -127,11 +115,8 @@ export class StoreCodeProposal extends JSONSerializable<
 
   public static fromProto(
     proto: StoreCodeProposal.Proto,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): StoreCodeProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return new StoreCodeProposal(
       proto.title,
       proto.description,
@@ -143,10 +128,7 @@ export class StoreCodeProposal extends JSONSerializable<
     );
   }
 
-  public toProto(isClassic?: boolean): StoreCodeProposal.Proto {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toProto(_isClassic?: boolean): StoreCodeProposal.Proto {
     const {
       title,
       description,
@@ -164,9 +146,6 @@ export class StoreCodeProposal extends JSONSerializable<
   }
 
   public packAny(isClassic?: boolean): Any {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return Any.fromPartial({
       typeUrl: '/cosmwasm.wasm.v1.StoreCodeProposal',
       value: StoreCodeProposal_pb.encode(this.toProto(isClassic)).finish(),
@@ -174,9 +153,6 @@ export class StoreCodeProposal extends JSONSerializable<
   }
 
   public static unpackAny(msgAny: Any, isClassic?: boolean): StoreCodeProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return StoreCodeProposal.fromProto(
       StoreCodeProposal_pb.decode(msgAny.value),
       isClassic

--- a/src/core/wasm/proposals/SudoContractProposal.ts
+++ b/src/core/wasm/proposals/SudoContractProposal.ts
@@ -25,21 +25,15 @@ export class SudoContractProposal extends JSONSerializable<
 
   public static fromAmino(
     data: SudoContractProposal.Amino,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): SudoContractProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     const {
       value: { title, description, contract, msg },
     } = data as SudoContractProposal.Amino;
     return new SudoContractProposal(title, description, contract, msg);
   }
 
-  public toAmino(isClassic?: boolean): SudoContractProposal.Amino {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toAmino(_isClassic?: boolean): SudoContractProposal.Amino {
     const { title, description, contract, msg } = this;
     return {
       type: 'wasm/SudoContractProposal',
@@ -54,11 +48,8 @@ export class SudoContractProposal extends JSONSerializable<
 
   public static fromProto(
     proto: SudoContractProposal.Proto,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): SudoContractProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return new SudoContractProposal(
       proto.title,
       proto.description,
@@ -67,10 +58,7 @@ export class SudoContractProposal extends JSONSerializable<
     );
   }
 
-  public toProto(isClassic?: boolean): SudoContractProposal.Proto {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toProto(_isClassic?: boolean): SudoContractProposal.Proto {
     const { title, description, contract, msg } = this;
     return SudoContractProposal_pb.fromPartial({
       title,
@@ -80,9 +68,6 @@ export class SudoContractProposal extends JSONSerializable<
     });
   }
   public packAny(isClassic?: boolean): Any {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return Any.fromPartial({
       typeUrl: '/cosmwasm.wasm.v1.SudoContractProposal',
       value: SudoContractProposal_pb.encode(this.toProto(isClassic)).finish(),
@@ -93,9 +78,6 @@ export class SudoContractProposal extends JSONSerializable<
     msgAny: Any,
     isClassic?: boolean
   ): SudoContractProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return SudoContractProposal.fromProto(
       SudoContractProposal_pb.decode(msgAny.value),
       isClassic
@@ -104,20 +86,14 @@ export class SudoContractProposal extends JSONSerializable<
 
   public static fromData(
     data: SudoContractProposal.Data,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): SudoContractProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     const { title, description, contract, msg } =
       data as SudoContractProposal.Data;
     return new SudoContractProposal(title, description, contract, msg);
   }
 
-  public toData(isClassic?: boolean): SudoContractProposal.Data {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toData(_isClassic?: boolean): SudoContractProposal.Data {
     const { title, description, contract, msg } = this;
     return {
       '@type': '/cosmwasm.wasm.v1.SudoContractProposal',

--- a/src/core/wasm/proposals/UnpinCodesProposal.ts
+++ b/src/core/wasm/proposals/UnpinCodesProposal.ts
@@ -27,11 +27,8 @@ export class UnpinCodesProposal extends JSONSerializable<
 
   public static fromAmino(
     data: UnpinCodesProposal.Amino,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): UnpinCodesProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     const {
       value: { title, description, code_ids },
     } = data as UnpinCodesProposal.Amino;
@@ -42,10 +39,7 @@ export class UnpinCodesProposal extends JSONSerializable<
     );
   }
 
-  public toAmino(isClassic?: boolean): UnpinCodesProposal.Amino {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toAmino(_isClassic?: boolean): UnpinCodesProposal.Amino {
     const { title, description, code_ids } = this;
     return {
       type: 'wasm/UnpinCodesProposal',
@@ -59,11 +53,8 @@ export class UnpinCodesProposal extends JSONSerializable<
 
   public static fromProto(
     proto: UnpinCodesProposal.Proto,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): UnpinCodesProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return new UnpinCodesProposal(
       proto.title,
       proto.description,
@@ -71,10 +62,7 @@ export class UnpinCodesProposal extends JSONSerializable<
     );
   }
 
-  public toProto(isClassic?: boolean): UnpinCodesProposal.Proto {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toProto(_isClassic?: boolean): UnpinCodesProposal.Proto {
     const { title, description, code_ids } = this;
     return UnpinCodesProposal_pb.fromPartial({
       title,
@@ -83,9 +71,6 @@ export class UnpinCodesProposal extends JSONSerializable<
     });
   }
   public packAny(isClassic?: boolean): Any {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return Any.fromPartial({
       typeUrl: '/cosmwasm.wasm.v1.UnpinCodesProposal',
       value: UnpinCodesProposal_pb.encode(this.toProto(isClassic)).finish(),
@@ -96,9 +81,6 @@ export class UnpinCodesProposal extends JSONSerializable<
     msgAny: Any,
     isClassic?: boolean
   ): UnpinCodesProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return UnpinCodesProposal.fromProto(
       UnpinCodesProposal_pb.decode(msgAny.value),
       isClassic
@@ -107,11 +89,8 @@ export class UnpinCodesProposal extends JSONSerializable<
 
   public static fromData(
     data: UnpinCodesProposal.Data,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): UnpinCodesProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     const { title, description, code_ids } = data as UnpinCodesProposal.Data;
     return new UnpinCodesProposal(
       title,
@@ -120,10 +99,7 @@ export class UnpinCodesProposal extends JSONSerializable<
     );
   }
 
-  public toData(isClassic?: boolean): UnpinCodesProposal.Data {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toData(_isClassic?: boolean): UnpinCodesProposal.Data {
     const { title, description, code_ids } = this;
     return {
       '@type': '/cosmwasm.wasm.v1.UnpinCodesProposal',

--- a/src/core/wasm/proposals/UpdateAdminProposal.ts
+++ b/src/core/wasm/proposals/UpdateAdminProposal.ts
@@ -26,21 +26,15 @@ export class UpdateAdminProposal extends JSONSerializable<
 
   public static fromAmino(
     data: UpdateAdminProposal.Amino,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): UpdateAdminProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     const {
       value: { title, description, contract, new_admin },
     } = data as UpdateAdminProposal.Amino;
     return new UpdateAdminProposal(title, description, contract, new_admin);
   }
 
-  public toAmino(isClassic?: boolean): UpdateAdminProposal.Amino {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toAmino(_isClassic?: boolean): UpdateAdminProposal.Amino {
     const { title, description, contract, new_admin } = this;
     return {
       type: 'wasm/UpdateAdminProposal',
@@ -55,11 +49,8 @@ export class UpdateAdminProposal extends JSONSerializable<
 
   public static fromProto(
     proto: UpdateAdminProposal.Proto,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): UpdateAdminProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return new UpdateAdminProposal(
       proto.title,
       proto.description,
@@ -68,10 +59,7 @@ export class UpdateAdminProposal extends JSONSerializable<
     );
   }
 
-  public toProto(isClassic?: boolean): UpdateAdminProposal.Proto {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toProto(_isClassic?: boolean): UpdateAdminProposal.Proto {
     const { title, description, contract, new_admin } = this;
     return UpdateAdminProposal_pb.fromPartial({
       title,
@@ -81,9 +69,6 @@ export class UpdateAdminProposal extends JSONSerializable<
     });
   }
   public packAny(isClassic?: boolean): Any {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return Any.fromPartial({
       typeUrl: '/cosmwasm.wasm.v1.UpdateAdminProposal',
       value: UpdateAdminProposal_pb.encode(this.toProto(isClassic)).finish(),
@@ -94,9 +79,6 @@ export class UpdateAdminProposal extends JSONSerializable<
     msgAny: Any,
     isClassic?: boolean
   ): UpdateAdminProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return UpdateAdminProposal.fromProto(
       UpdateAdminProposal_pb.decode(msgAny.value),
       isClassic
@@ -105,20 +87,14 @@ export class UpdateAdminProposal extends JSONSerializable<
 
   public static fromData(
     data: UpdateAdminProposal.Data,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): UpdateAdminProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     const { title, description, contract, new_admin } =
       data as UpdateAdminProposal.Data;
     return new UpdateAdminProposal(title, description, contract, new_admin);
   }
 
-  public toData(isClassic?: boolean): UpdateAdminProposal.Data {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toData(_isClassic?: boolean): UpdateAdminProposal.Data {
     const { title, description, contract, new_admin } = this;
     return {
       '@type': '/cosmwasm.wasm.v1.UpdateAdminProposal',

--- a/src/core/wasm/proposals/UpdateInstantiateConfigProposal.ts
+++ b/src/core/wasm/proposals/UpdateInstantiateConfigProposal.ts
@@ -27,11 +27,8 @@ export class UpdateInstantiateConfigProposal extends JSONSerializable<
 
   public static fromAmino(
     data: UpdateInstantiateConfigProposal.Amino,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): UpdateInstantiateConfigProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     const {
       value: { title, description, access_config_updates },
     } = data as UpdateInstantiateConfigProposal.Amino;
@@ -42,10 +39,7 @@ export class UpdateInstantiateConfigProposal extends JSONSerializable<
     );
   }
 
-  public toAmino(isClassic?: boolean): UpdateInstantiateConfigProposal.Amino {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toAmino(_isClassic?: boolean): UpdateInstantiateConfigProposal.Amino {
     const { title, description, access_config_updates } = this;
     return {
       type: 'wasm/UpdateInstantiateConfigProposal',
@@ -59,11 +53,8 @@ export class UpdateInstantiateConfigProposal extends JSONSerializable<
 
   public static fromProto(
     proto: UpdateInstantiateConfigProposal.Proto,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): UpdateInstantiateConfigProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return new UpdateInstantiateConfigProposal(
       proto.title,
       proto.description,
@@ -71,10 +62,7 @@ export class UpdateInstantiateConfigProposal extends JSONSerializable<
     );
   }
 
-  public toProto(isClassic?: boolean): UpdateInstantiateConfigProposal.Proto {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toProto(_isClassic?: boolean): UpdateInstantiateConfigProposal.Proto {
     const { title, description, access_config_updates } = this;
     return UpdateInstantiateConfigProposal_pb.fromPartial({
       title,
@@ -83,9 +71,6 @@ export class UpdateInstantiateConfigProposal extends JSONSerializable<
     });
   }
   public packAny(isClassic?: boolean): Any {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return Any.fromPartial({
       typeUrl: '/cosmwasm.wasm.v1.UpdateInstantiateConfigProposal',
       value: UpdateInstantiateConfigProposal_pb.encode(
@@ -98,9 +83,6 @@ export class UpdateInstantiateConfigProposal extends JSONSerializable<
     msgAny: Any,
     isClassic?: boolean
   ): UpdateInstantiateConfigProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     return UpdateInstantiateConfigProposal.fromProto(
       UpdateInstantiateConfigProposal_pb.decode(msgAny.value),
       isClassic
@@ -109,11 +91,8 @@ export class UpdateInstantiateConfigProposal extends JSONSerializable<
 
   public static fromData(
     data: UpdateInstantiateConfigProposal.Data,
-    isClassic?: boolean
+    _isClassic?: boolean
   ): UpdateInstantiateConfigProposal {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
     const { title, description, access_config_updates } =
       data as UpdateInstantiateConfigProposal.Data;
     return new UpdateInstantiateConfigProposal(
@@ -123,10 +102,7 @@ export class UpdateInstantiateConfigProposal extends JSONSerializable<
     );
   }
 
-  public toData(isClassic?: boolean): UpdateInstantiateConfigProposal.Data {
-    if (isClassic) {
-      throw new Error('Not supported for the network');
-    }
+  public toData(_isClassic?: boolean): UpdateInstantiateConfigProposal.Data {
     const { title, description, access_config_updates } = this;
     return {
       '@type': '/cosmwasm.wasm.v1.UpdateInstantiateConfigProposal',


### PR DESCRIPTION
Dear @alecande11,

We politely ask you to review this PR and get it merged so that end-users can have flawless experience on station mobile. We figured the changes in #356 may have been too many to get quickly reviewed and merged. This is why we tried to condense it down to a bare minimum for you guys to be easier reviewable. We will close #356 in favor of this PR. Thank you so much for your ongoing support.

Changes:

- Support WASM related proposal types
- Support canonical WASM API for classic

Humbly,
Till